### PR TITLE
Update build process

### DIFF
--- a/before_build.cmd
+++ b/before_build.cmd
@@ -1,2 +1,1 @@
-call setup.cmd
 set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%

--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,8 @@
 @echo off
 cls
 
+call npm install
+
 .paket\paket.bootstrapper.exe
 if errorlevel 1 (
   exit /b %errorlevel%

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,8 @@ else
   MONO="mono"
 fi
 
+npm install
+
 $MONO .paket/paket.bootstrapper.exe
 exit_code=$?
 if [ $exit_code -ne 0 ]; then

--- a/setup.cmd
+++ b/setup.cmd
@@ -1,1 +1,0 @@
-call npm install


### PR DESCRIPTION
Moves calling `npm install` to `build.cmd` and `build.sh`

1. Makes setup easier for user doing fresh clone of repo - no need to run 2 separate commands
1. Makes downloading Fable using Paket v3 git support easier 
1. If developer add any new node dependency for Fable there is no need to run `npm install` separately