### PR TITLE
[doc] Fix GH-pages doc URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,11 +44,11 @@ Some of its main features are:</p>
 <li>Optimizes F# code to generate as clean JavaScript as possible</li>
 <li>Passes location data to Babel to generate source maps</li>
 <li>Compatible with all Babel plugins and other JS development tools, like Webpack</li>
-<li><a href="docs/compatibility.md">Support for most of the F# core library and a bit of .NET Base Class Library</a></li>
+<li><a href="https://github.com/fsprojects/Fable/blob/master/docs/compatibility.md">Support for most of the F# core library and a bit of .NET Base Class Library</a></li>
 <li>Tiny core library included without runtime</li>
 <li>Organizes code using ES6 modules </li>
 <li>Interacts seamlessly with other JavaScript libraries</li>
-<li>Bonus: <a href="docs/testing.md">compile NUnit tests to Mocha</a>
+<li>Bonus: <a href="https://github.com/fsprojects/Fable/blob/master/docs/testing.md">compile NUnit tests to Mocha</a>
 </li>
 </ul>
 
@@ -80,7 +80,7 @@ Download the repo and run:</p>
 npm install         // both platforms, installs node dependencies
 </code></pre>
 
-<p>If everything works, follow <a href="docs/compiling.md">these instructions</a> to compile a F# project or script file to JS.</p>
+<p>If everything works, follow <a href="https://github.com/fsprojects/Fable/blob/master/docs/compiling.md">these instructions</a> to compile a F# project or script file to JS.</p>
 
 <h2>
 <a id="contributing" class="anchor" href="#contributing" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Contributing</h2>
@@ -116,7 +116,7 @@ to the last expression in many functions. This is normal and due to the optimiza
 on the generated code.</p></li>
 </ul>
 
-<p>To know more, read <a href="docs/compatibility.md">Compatibility</a>.</p>
+<p>To know more, read <a href="https://github.com/fsprojects/Fable/blob/master/docs/compatibility.md">Compatibility</a>.</p>
 
 <h2>
 <a id="acknowledgements" class="anchor" href="#acknowledgements" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Acknowledgements</h2>


### PR DESCRIPTION
The links are broken but I'm not sure if this PR is relevant if you auto-create it from the `readme.md`.