### PR TITLE
Support for HashSet. Argument order for Assert.AreEqual(). Minor cleanup.

### DIFF
--- a/src/fable-fsharp/Replacements.fs
+++ b/src/fable-fsharp/Replacements.fs
@@ -437,6 +437,11 @@ module private AstPass =
             prop "length" i.callee.Value |> Some
         | _ -> None
 
+    let languagePrimitives com (i: Fable.ApplyInfo) =
+        match i.methodName, (i.callee, i.args) with
+        | "enumOfValue", OneArg (arg) -> arg |> Some
+        | _ -> None
+
     let intrinsicFunctions com (i: Fable.ApplyInfo) =
         match i.methodName, (i.callee, i.args) with
         | "checkThis", _ -> Fable.This |> Fable.Value |> Some
@@ -923,6 +928,7 @@ module private AstPass =
         | "Microsoft.FSharp.Core.ExtraTopLevelOperators" -> operators com info
         | "Microsoft.FSharp.Core.Ref" -> references com info
         | "System.Activator"
+        | "Microsoft.FSharp.Core.LanguagePrimitives" -> languagePrimitives com info
         | "Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicFunctions"
         | "Microsoft.FSharp.Core.Operators.OperatorIntrinsics" -> intrinsicFunctions com info
         | "System.Text.RegularExpressions.Capture"

--- a/src/fable-fsharp/Replacements.fs
+++ b/src/fable-fsharp/Replacements.fs
@@ -592,7 +592,6 @@ module private AstPass =
         | "count" -> prop "size" |> Some
         | "contains" | "containsKey" -> icall "has" |> Some
         | "remove" ->
-            let m = Map.empty<int,int>
             let callee, args = instanceArgs()
             CoreLibCall(modName, Some "remove", false, [args.Head; callee])
             |> makeCall com i.range i.returnType |> Some

--- a/src/fable-js/fable-core.js
+++ b/src/fable-js/fable-core.js
@@ -1518,6 +1518,20 @@
   FSet.isSupersetOf = FSet.isSuperset = function (set1, set2) {
     return FSet.isSubset(set2, set1);
   };
+  FSet.copyTo = function (xs, arr, arrayIndex, count) {
+      if (!arr instanceof Array)
+          throw "Array is invalid";
+
+      count = count || arr.length;
+      var i = arrayIndex || 0;
+      var iter = xs[Symbol.iterator]();
+      while (count--) {
+          var el = iter.next();
+          if (el.done)
+              break;
+          arr[i++] = el.value;
+      };
+  };
   FSet.partition = function (f, xs) {
     return Seq.fold(function (acc, x) {
       var lacc = acc[0], racc = acc[1];

--- a/src/plugins/Fable.Plugins.NUnit.fsx
+++ b/src/plugins/Fable.Plugins.NUnit.fsx
@@ -54,7 +54,7 @@ module Util =
     let asserts com (i: Fable.ApplyInfo) =
         match i.methodName with
         | "areEqual" ->
-            Fable.Util.ImportCall("assert", true, None, Some "equal", false, i.args)
+            Fable.Util.ImportCall("assert", true, None, Some "equal", false, List.rev i.args)
             |> Fable.Util.makeCall com i.range i.returnType |> Some
         | _ -> None
 

--- a/src/tests/Fable.Tests.fsproj
+++ b/src/tests/Fable.Tests.fsproj
@@ -58,6 +58,7 @@
     <Compile Include="SeqTests.fs" />
     <Compile Include="SetTests.fs" />
     <Compile Include="StringTests.fs" />
+    <Compile Include="SystemSetsTests.fs" />
     <Compile Include="TupleTypeTests.fs" />
     <Compile Include="UnionTypeTests.fs" />
   </ItemGroup>

--- a/src/tests/SystemSetsTests.fs
+++ b/src/tests/SystemSetsTests.fs
@@ -1,0 +1,89 @@
+[<NUnit.Framework.TestFixture>] 
+module Fable.Tests.SystemSets
+open System
+open System.Collections.Generic
+open NUnit.Framework
+open Fable.Tests.Util
+
+[<Test>]
+let ``HashSet creation works``() =
+    let hs = HashSet<_>()
+    equal 0 hs.Count
+
+[<Test>]
+let ``HashSet iteration works``() =
+    let hs = HashSet<_>()
+    for i in 1. .. 10. do hs.Add(i*i) |> ignore
+
+    let i = ref 0.
+    for v in hs do
+       i := v + !i
+    equal 385. !i
+
+[<Test>]
+let ``HashSet folding works``() =
+    let hs = HashSet<_>()
+    for i in 1. .. 10. do hs.Add(i*i) |> ignore
+    hs |> Seq.fold (fun acc item -> acc + item) 0.
+    |> equal 385.
+
+[<Test>]
+let ``HashSet.Count works``() =
+    let hs = HashSet<_>()
+    for i in 1. .. 10. do hs.Add(i*i) |> ignore
+    hs.Count
+    |> equal 10
+
+[<Test>]
+let ``HashSet.Add works``() =
+    let hs = HashSet<_>()
+    hs.Add("A", "Hello") |> ignore
+    hs.Add("B", "World!") |> ignore
+    hs.Count |> equal 2
+
+[<Test>]
+let ``HashSet.Clear works``() =
+    let hs = HashSet<_>()
+    hs.Add("A", 1) |> ignore
+    hs.Add("B", 2) |> ignore
+    hs.Clear()
+    hs.Count |> equal 0
+
+[<Test>]
+let ``HashSet.Contains works``() =
+    let hs = HashSet<_>()
+    hs.Add("Hello") |> ignore
+    hs.Add("World!") |> ignore
+    hs.Contains("Hello") |> equal true
+    hs.Contains("Everybody!") |> equal false
+
+[<Test>]
+let ``HashSet.CopyTo works``() =
+    let hs = HashSet<_>()
+    for i in 1 .. 9 do hs.Add(i) |> ignore
+
+    let arr1 = Array.zeroCreate 9
+    let arr2 = Array.zeroCreate 11
+    let arr3 = Array.zeroCreate 7
+
+    hs.CopyTo(arr1)         // [|1;2;3;4;5;6;7;8;9|]
+    hs.CopyTo(arr2, 2)      // [|0;0;1;2;3;4;5;6;7;8;9|]
+    hs.CopyTo(arr3, 3, 4)   // [|0;0;0;1;2;3;4|]
+
+    let sum = fun acc item -> acc + item
+    arr1 |> Seq.fold sum 0 |> equal 45
+    arr1.Length |> equal 9
+
+    arr2 |> Seq.fold sum 0 |> equal 45
+    arr2.Length |> equal 11
+
+    arr3 |> Seq.fold sum 0 |> equal 10
+    arr3.Length |> equal 7
+
+[<Test>]
+let ``HashSet.Remove works``() =
+    let hs = HashSet<_>()
+    hs.Add("A") |> ignore
+    hs.Add("B") |> ignore
+    hs.Remove("A") |> equal true
+    hs.Remove("C") |> equal false

--- a/src/tests/Util/Util.fs
+++ b/src/tests/Util/Util.fs
@@ -4,7 +4,7 @@ open System
 open NUnit.Framework
 
 let equal (expected: 'T) (actual: 'T) =
-    Assert.AreEqual(actual, expected)
+    Assert.AreEqual(expected, actual)
 
 type Helper =
     static member Format(pattern: string, [<ParamArray>] args: obj[]) =


### PR DESCRIPTION
Initial support for HashSets (closes #78).

Also, during the tests I found the order of 'actual' and 'expected' arguments reversed(?!). Both in Utils.fs and in NUnit plugin (which makes the output to appear "correct" in Mocha -- But running them in F#/NUnit shows the values in the wrong order).
