### PR TITLE
Fix printfn "%A" output for TypedArrrays.

### DIFF
--- a/src/fable-js/fable-core.js
+++ b/src/fable-js/fable-core.js
@@ -315,7 +315,9 @@
           case "f": case "F": rep = rep.toFixed(precision || 6); break;
           case "g": case "G": rep = rep.toPrecision(precision); break;
           case "e": case "E": rep = rep.toExponential(precision); break;
-          case "A": rep = JSON.stringify(rep); break;
+          case "A": rep = JSON.stringify(rep, function(k, v) {
+                        return ArrayBuffer.isView(v) ? Array.from(v) : v;
+                    }); break;
         }
         var plusPrefix = flags.indexOf('+') >= 0 && parseInt(rep) >= 0;
         if (!isNaN(pad = parseInt(pad))) {

--- a/src/fable-js/fable-core.js
+++ b/src/fable-js/fable-core.js
@@ -315,9 +315,15 @@
           case "f": case "F": rep = rep.toFixed(precision || 6); break;
           case "g": case "G": rep = rep.toPrecision(precision); break;
           case "e": case "E": rep = rep.toExponential(precision); break;
-          case "A": rep = JSON.stringify(rep, function(k, v) {
-                        return ArrayBuffer.isView(v) ? Array.from(v) : v;
-                    }); break;
+          case "A": 
+            rep = ( (rep instanceof Map) ? "map " : 
+                    (rep instanceof Set) ? "set " : "") + JSON.stringify(rep, function(k, v) {
+                    return v && v[Symbol.iterator] 
+                             && !Array.isArray(v) 
+                             && !(typeof v === 'string' || v instanceof String)
+                             ? Array.from(v) : v;
+                  });
+            break;
         }
         var plusPrefix = flags.indexOf('+') >= 0 && parseInt(rep) >= 0;
         if (!isNaN(pad = parseInt(pad))) {


### PR DESCRIPTION
My suggestion to avoid another fright like #87 ;'-)

Uses [ArrayBuffer.isView](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView) to check for TypedArrays and the [second parameter of JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter) to convert it to Array.