### PR TITLE
Change union internal format

### DIFF
--- a/import/core/fable-core.js
+++ b/import/core/fable-core.js
@@ -24,8 +24,8 @@
   };
   
   exports.Choice = function Choice(t, d) {
-    this.tag = t;
-    this.data0 = d;
+    this.Case = t;
+    this.Fields = [d];
   };
 
   var Util = exports.Util = {};
@@ -1934,13 +1934,13 @@
     return [
       Obs.choose(function (v) {
         var res = f(v);
-        return res.tag == "Choice1Of2"
-          ? res.data0 : null;
+        return res.Case == "Choice1Of2"
+          ? res.Fields[0] : null;
       }, w),
       Obs.choose(function (v) {
         var res = f(v);
-        return res.tag == "Choice2Of2"
-          ? res.data0 : null;
+        return res.Case == "Choice2Of2"
+          ? res.Fields[0] : null;
       }, w),
     ];
   };

--- a/src/fable-fsharp/AST/AST.Fable.fs
+++ b/src/fable-fsharp/AST/AST.Fable.fs
@@ -404,7 +404,7 @@ module Util =
         | _ -> failwithf "Unsupported type test in %A: %A" range typ
 
     let makeUnionCons () =
-        let emit = Emit "this.tag=arguments[0]; for (var i=1; i<arguments.length; i++) { this['data'+(i-1)]=arguments[i]; }" |> Value
+        let emit = Emit "this.Case=arguments[0]; this.Fields = []; for (var i=1; i<arguments.length; i++) { this.Fields[(i-1)]=arguments[i]; }" |> Value
         let body = Apply (emit, [], ApplyMeth, PrimitiveType Unit, None)
         Member(Constructor, SourceLocation.Empty, [], body, [], true)
         |> MemberDeclaration

--- a/src/fable-fsharp/FSharp2Fable.fs
+++ b/src/fable-fsharp/FSharp2Fable.fs
@@ -231,7 +231,8 @@ let rec private transformExpr (com: IFableCompiler) ctx fsExpr =
         | OtherType ->
             let typ, range = makeType com ctx fsExpr.Type, makeRangeFrom fsExpr
             let i = unionCase.UnionCaseFields |> Seq.findIndex (fun x -> x.Name = fieldName)
-            makeGet range typ unionExpr (sprintf "data%i" i |> makeConst)
+            let fields = makeGet range typ unionExpr ("Fields" |> makeConst)
+            makeGet range typ fields (i |> makeConst)
 
     | BasicPatterns.ILFieldSet (callee, typ, fieldName, value) ->
         failwithf "Found unsupported ILField reference in %A: %A" fsExpr.Range fsExpr
@@ -407,7 +408,7 @@ let rec private transformExpr (com: IFableCompiler) ctx fsExpr =
             let expr = makeGet None Fable.UnknownType unionExpr (makeConst "tail")
             makeBinOp (makeRangeFrom fsExpr) boolType [expr; Fable.Value Fable.Null] opKind 
         | OtherType ->
-            let left = makeGet None (Fable.PrimitiveType Fable.String) unionExpr (makeConst "tag")
+            let left = makeGet None (Fable.PrimitiveType Fable.String) unionExpr (makeConst "Case")
             let right = makeConst unionCase.Name
             makeBinOp (makeRangeFrom fsExpr) boolType [left; right] BinaryEqualStrict
 


### PR DESCRIPTION
Changing tags to Case and dataX to Fields[X] means that out the box fable can parse json produced by json.net