### PR TITLE
Change react children from List to Seq

### DIFF
--- a/import/react/Fable.Helpers.React.fs
+++ b/import/react/Fable.Helpers.React.fs
@@ -578,17 +578,17 @@ type Component<'P,'S>(props: 'P, ?state: 'S) =
     inherit React.Component<'P,'S>(props)
     do this?state <- state
 
-let inline fn (f: 'Props -> #React.ReactElement<obj>) (props: 'Props) (children: React.ReactElement<obj> list): React.ReactElement<obj> =
-    unbox(React.createElement(U2.Case1(unbox f), props, unbox(List.toArray children)))
+let inline fn (f: 'Props -> #React.ReactElement<obj>) (props: 'Props) (children: React.ReactElement<obj> seq): React.ReactElement<obj> =
+    unbox(React.createElement(U2.Case1(unbox f), props, unbox(Seq.toArray children)))
 
-let inline com<'T,'P,'S when 'T :> React.Component<'P,'S>> (props: 'P) (children: React.ReactElement<obj> list): React.ReactElement<obj> =
-    unbox(React.createElement(U2.Case1(unbox typeof<'T>), props, unbox(List.toArray children)))
+let inline com<'T,'P,'S when 'T :> React.Component<'P,'S>> (props: 'P) (children: React.ReactElement<obj> seq): React.ReactElement<obj> =
+    unbox(React.createElement(U2.Case1(unbox typeof<'T>), props, unbox(Seq.toArray children)))
 
-let inline domEl (tag: string) (props: IHTMLProp list) (children: React.ReactElement<obj> list): React.ReactElement<obj> =
-    unbox(React.createElement(tag, props, unbox(List.toArray children)))
+let inline domEl (tag: string) (props: IHTMLProp list) (children: React.ReactElement<obj> seq): React.ReactElement<obj> =
+    unbox(React.createElement(tag, props, unbox(Seq.toArray children)))
 
-let inline svgEl (tag: string) (props: #IProp list) (children: React.ReactElement<obj> list): React.ReactElement<obj> =
-    unbox(React.createElement(tag, props, unbox(List.toArray children)))
+let inline svgEl (tag: string) (props: #IProp list) (children: React.ReactElement<obj> seq): React.ReactElement<obj> =
+    unbox(React.createElement(tag, props, unbox(Seq.toArray children)))
 
 let inline a b c = domEl "a" b c
 let inline abbr b c = domEl "abbr" b c


### PR DESCRIPTION
This means you can still use lists but you can pass in an array - This means Fable doesn't have to create an array, convert it into a list the back into array, giving a little performance boost.