### PR TITLE
Use an erased union as the input to fetch

### DIFF
--- a/import/fetch/Fable.Import.Fetch.fs
+++ b/import/fetch/Fable.Import.Fetch.fs
@@ -79,8 +79,10 @@ module Fetch =
     and BodyInit =
         U3<Browser.Blob, Browser.FormData, string>
 
-    and RequestInfo =
-        U2<Request, string>
+    [<Erase>]
+    type RequestInfo =
+        | Url of string
+        | Req of Request
         
-    type Globals =
-        static member fetch (url: U2<string,Request>, ?init: RequestInit) =  failwith "JS only" :Promise<Response>
+    type GlobalFetch =
+        [<Global>]static member fetch (req: RequestInfo, ?init: RequestInit) =  failwith "JS only" :Promise<Response>


### PR DESCRIPTION
So syntax for a normal fetch would be:
```fsharp
GlobalFetch.fetch (Url “http://blah”)
```