### PR TITLE
Ensure that NUnit tests using String.format will pass regardless of current culture

### DIFF
--- a/src/tests/StringTests.fs
+++ b/src/tests/StringTests.fs
@@ -1,4 +1,5 @@
-[<NUnit.Framework.TestFixture>] 
+[<NUnit.Framework.TestFixture>]
+[<NUnit.Framework.SetCultureAttribute("en-US")>]
 module Fable.Tests.Strings
 open System
 open NUnit.Framework


### PR DESCRIPTION
NUnit tests using String.format can fail, if you have a different default culture, so I explicity set culture for StringTests to be "en-US".

```
Errors and Failures:
1) Test Failure : Fable.Tests.Strings.Padding with String.Format works
     String lengths are both 10. Strings differ at index 8.
  Expected: "       3.1"
  But was:  "       3,1"
  -------------------^

at Fable.Tests.Strings.Padding with String.Format works() in C:\dev\Fable\src\tests\StringTests.fs:line 51

2) Test Failure : Fable.Tests.Strings.String.Format with extra formatting works
     String lengths are both 27. Strings differ at index 1.
  Expected: "0.55 54.67 % 14/09/26 00:19"
  But was:  "0,55 54,67 % 14.09.26 00:19"
  ------------^

at Fable.Tests.Strings.String.Format with extra formatting works() in C:\dev\Fable\src\tests\StringTests.fs:line 31
```


