### PR TITLE
Counter and todomvc with Elm architecture

### DIFF
--- a/samples/browser/virtualdom/Fable.Helpers.Virtualdom.fsx
+++ b/samples/browser/virtualdom/Fable.Helpers.Virtualdom.fsx
@@ -1,0 +1,381 @@
+#r "node_modules/fable-core/Fable.Core.dll"
+
+module Html =
+    [<AutoOpen>]
+    module Types =
+        type MouseEvent =
+            {
+                altKey: bool
+                screenX: int
+                screenY: int
+            }
+        type KeyboardEvent =
+            {
+                code: string
+            }
+
+        type MouseEventHandler = string*(MouseEvent -> unit)
+        type KeyboardEventHandler = string*(KeyboardEvent -> unit)
+        type EventHandler = string*(obj -> unit)
+
+        type EventHandlerBinding =
+            | MouseEventHandler of MouseEventHandler
+            | KeyboardEventHandler of KeyboardEventHandler
+            | EventHandler of EventHandler
+
+        type Style = (string*string) list
+
+        type KeyValue = string*string
+
+        type Attribute =
+        | EventHandlerBinding of EventHandlerBinding
+        | Style of Style
+        | Property of KeyValue
+        | Attribute of KeyValue
+
+        type Element = string * Attribute list
+        /// A Node in Html have the following forms
+        type VoidElement = string * Attribute list
+        type Node =
+        /// A regular html element that can contain a list of other nodes
+        | Element of Element * Node list
+        /// A void element is one that can't have content, like link, br, hr, meta
+        /// See: https://dev.w3.org/html5/html-author/#void
+        | VoidElement of VoidElement
+        /// A text value for a node
+        | Text of string
+        /// Whitespace for formatting
+        | WhiteSpace of string
+
+    [<AutoOpen>]
+    module Tags =
+        let elem tagName attrs children = Element((tagName, attrs), children)
+        let voidElem tagName attrs = VoidElement(tagName, attrs)
+
+        let whiteSpace = WhiteSpace
+        let text = Text
+
+        // Elements - list of elements here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+        // Void elements
+        let br = voidElem "br"
+        let area = voidElem "area"
+        let baseHtml = voidElem "base"
+        let col = voidElem "col"
+        let embed = voidElem "embed"
+        let hr = voidElem "hr"
+        let img = voidElem "img"
+        let input = voidElem "input"
+        let link = voidElem "link"
+        let meta = voidElem "meta"
+        let param = voidElem "param"
+        let source = voidElem "source"
+        let track = voidElem "track"
+        let wbr = voidElem "wbr"
+
+        // Metadata
+        let head = elem "head"
+        let style = elem "style"
+        let title = elem "title"
+
+        // Content sectioning
+        let address = elem "address"
+        let article = elem "article"
+        let aside = elem "aside"
+        let footer = elem "footer"
+        let header = elem "header"
+        let h1 = elem "h1"
+        let h2 = elem "h2"
+        let h3 = elem "h3"
+        let h4 = elem "h4"
+        let h5 = elem "h5"
+        let h6 = elem "h6"
+        let hgroup = elem "hgroup"
+        let nav = elem "nav"
+
+        // Text content
+        let dd = elem "dd"
+        let div = elem "div"
+        let dl = elem "dl"
+        let dt = elem "dt"
+        let figcaption = elem "figcaption"
+        let figure = elem "figure"
+        let li = elem "li"
+        let main = elem "main"
+        let ol = elem "ol"
+        let p = elem "p"
+        let pre = elem "pre"
+        let section = elem "section"
+        let ul = elem "ul"
+
+        // Inline text semantics
+        let a = elem "a"
+        let abbr = elem "abbr"
+        let b = elem "b"
+        let bdi = elem "bdi"
+        let bdo = elem "bdo"
+        let cite = elem "cite"
+        let code = elem "code"
+        let data = elem "data"
+        let dfn = elem "dfn"
+        let em = elem "em"
+        let i = elem "i"
+        let kbd = elem "kbd"
+        let mark = elem "mark"
+        let q = elem "q"
+        let rp = elem "rp"
+        let rt = elem "rt"
+        let rtc = elem "rtc"
+        let ruby = elem "ruby"
+        let s = elem "s"
+        let samp = elem "samp"
+        let small = elem "small"
+        let span = elem "span"
+        let strong = elem "strong"
+        let sub = elem "sub"
+        let sup = elem "sup"
+        let time = elem "time"
+        let u = elem "u"
+        let var = elem "var"
+
+        // Image and multimedia
+        let audio = elem "audio"
+        let map = elem "map"
+        let video = elem "video"
+
+        // Embedded content
+        let objectHtml = elem "object"
+
+        // Demarcasting edits
+        let del = elem "del"
+        let ins = elem "ins"
+
+        // Table content
+        let caption = elem "caption"
+        let colgroup = elem "colgroup"
+        let table = elem "table"
+        let tbody = elem "tbody"
+        let td = elem "td"
+        let tfoot = elem "tfoot"
+        let th = elem "th"
+        let thead = elem "thead"
+        let tr = elem "tr"
+
+        // Forms
+        let button = elem "button"
+        let datalist = elem "datalist"
+        let fieldset = elem "fieldset"
+        let form = elem "form"
+        let label = elem "label"
+        let legend = elem "legend"
+        let meter = elem "meter"
+        let optgroup = elem "optgroup"
+        let option = elem "option"
+        let output = elem "output"
+        let progress = elem "progress"
+        let select = elem "select"
+        let textarea = elem "textarea"
+
+        // Interactive elements
+        let details = elem "details"
+        let dialog = elem "dialog"
+        let menu = elem "menu"
+        let menuitem = elem "menuitem"
+        let summary = elem "summary"
+
+    [<AutoOpen>]
+    module Attributes =
+        let attribute key value = Attribute.Attribute (key,value)
+        let property key value = Attribute.Property (key,value)
+
+    [<AutoOpen>]
+    module Events =
+        let onMouseEvent eventType f = EventHandlerBinding (MouseEventHandler (eventType, f))
+
+        let onMouseClick = onMouseEvent "onclick"
+        let onContextMenu = onMouseEvent "oncontextmenu"
+        let onDblClick = onMouseEvent "ondblclick"
+        let onMouseDown = onMouseEvent "onmousedown"
+        let onMouseEnter = onMouseEvent "onmouseenter"
+        let onMouseLeave = onMouseEvent "onmouseleave"
+        let onMouseMove = onMouseEvent "onmousemove"
+        let onMouseOut = onMouseEvent "onmouseout"
+        let onMouseOver = onMouseEvent "onmouseover"
+        let onMouseUp = onMouseEvent "onmouseup"
+        let onShow = onMouseEvent "onshow"
+        let onKeyboardEvent eventType f = EventHandlerBinding (KeyboardEventHandler (eventType, f))
+        let onKeydown = onKeyboardEvent "onkeydown"
+        let onKeypress = onKeyboardEvent "onkeypress"
+        let onKeyup = onKeyboardEvent "onkeyup"
+
+        let onEvent eventType f = EventHandlerBinding (EventHandler (eventType, f))
+        let onAbort = onEvent "onabort"
+        let onAfterPrint = onEvent "onafterprint"
+        let onAudioEnd = onEvent "onaudioend"
+        let onAudioStart = onEvent "onaudiostart"
+        let onBeforePrint = onEvent "onbeforeprint"
+        let onCached = onEvent "oncached"
+        let onCanPlay = onEvent "oncanplay"
+        let onCanPlayThrough = onEvent "oncanplaythrough"
+        let onChange = onEvent "onchange"
+        let onChargingChange = onEvent "onchargingchange"
+        let onChargingTimeChange = onEvent "onchargingtimechange"
+        let onChecking = onEvent "onchecking"
+        let onClose = onEvent "onclose"
+        let onDischargingTimeChange = onEvent "ondischargingtimechange"
+        let onDOMContentLoaded = onEvent "onDOMContentLoaded"
+        let onDownloading = onEvent "ondownloading"
+        let onDurationchange = onEvent "ondurationchange"
+        let onEmptied = onEvent "onemptied"
+        let onEnd = onEvent "onend"
+        let onEnded = onEvent "onended"
+        let onError = onEvent "onerror"
+        let onCullScreenChange = onEvent "onfullscreenchange"
+        let onCullScreenError = onEvent "onfullscreenerror"
+        let onInput = onEvent "oninput"
+        let onInvalid = onEvent "oninvalid"
+        let onLanguageChange = onEvent "onlanguagechange"
+        let onLevelChange = onEvent "onlevelchange"
+        let onLoadedData = onEvent "onloadeddata"
+        let onLoadedMetaData = onEvent "onloadedmetadata"
+        let onNoUpdate = onEvent "onnoupdate"
+        let onObsolete = onEvent "onobsolete"
+        let onOffline = onEvent "onoffline"
+        let onOnline = onEvent "ononline"
+        let onOpen = onEvent "onopen"
+        let onOrientationChange = onEvent "onorientationchange"
+        let onPause = onEvent "onpause"
+        let onPointerlockchange = onEvent "onpointerlockchange"
+        let onPointerlockerror = onEvent "onpointerlockerror"
+        let onPlay = onEvent "onplay"
+        let onPlaying = onEvent "onplaying"
+        let onRateChange = onEvent "onratechange"
+        let onReadyStateChange = onEvent "onreadystatechange"
+        let onReset = onEvent "onreset"
+        let onSeeked = onEvent "onseeked"
+        let onSeeking = onEvent "onseeking"
+        let onSelectStart = onEvent "onselectstart"
+        let onSelectionChange = onEvent "onselectionchange"
+        let onSoundEnd = onEvent "onsoundend"
+        let onSoundStart = onEvent "onsoundstart"
+        let onSpeechEnd = onEvent "onspeechend"
+        let onSpeechStart = onEvent "onspeechstart"
+        let onStalled = onEvent "onstalled"
+        let onStart = onEvent "onstart"
+        let onSubmit = onEvent "onsubmit"
+        let onSuccess = onEvent "onsuccess"
+        let onSuspend = onEvent "onsuspend"
+        let onTimeUpdate = onEvent "ontimeupdate"
+        let onUpdateReady = onEvent "onupdateready"
+        let onVoicesChanged = onEvent "onvoiceschanged"
+        let onVisibilityChange = onEvent "onvisibilitychange"
+        let onVolumeChange = onEvent "onvolumechange"
+        let onVrdisplayConnected = onEvent "onvrdisplayconnected"
+        let onVrdisplayDisconnected = onEvent "onvrdisplaydisconnected"
+        let onVrdisplayPresentChange = onEvent "onvrdisplaypresentchange"
+        let onWaiting = onEvent "onwaiting"
+
+        let onBlur = onEvent "onblur"
+        let onFocus = onEvent "onfocus"
+
+open Html
+open Fable.Core
+open Fable.Core.Extensions
+open Fable.Import.Browser
+
+[<AutoOpen>]
+module App =
+    type Observer<'T>(next, error, completed) =
+        interface System.IObserver<'T> with
+            member x.OnCompleted() = completed()
+            member x.OnError(e) = error e
+            member x.OnNext(v) = next v
+
+    type AppState<'TModel, 'TMessage> = {
+            Model: 'TModel
+            View: 'TModel -> ('TMessage -> unit) -> Html.Types.Node
+            Update: 'TModel -> 'TMessage -> ('TModel * ((unit -> unit) list)) }
+
+
+    type AppEvents<'TMessage, 'TModel> =
+        | ModelChanged of 'TModel*'TModel
+        | ActionReceived of 'TMessage
+
+    type Subscriber<'TMessage, 'TModel> = AppEvents<'TMessage, 'TModel> -> unit
+
+    type App<'TModel, 'TMessage> =
+        {
+            AppState: AppState<'TModel, 'TMessage>
+            Node: Node option
+            CurrentTree: obj option
+            Subscribers: Map<string, Subscriber<'TMessage, 'TModel>>
+            NodeSelector: string option
+        }
+
+    let createApp appState =
+        {
+            AppState = appState
+            Node = None
+            CurrentTree = None
+            Subscribers = Map.empty
+            NodeSelector = None
+        }
+
+    let withStartNode selector app = { app with NodeSelector = Some selector }
+    let withSubscriber subscriberId subscriber app =
+        let subsribers = app.Subscribers |> Map.add subscriberId subscriber
+        { app with Subscribers = subsribers }
+
+    type AppMessage<'TMessage> =
+        | AddSubscriber of string*Subscriber<'TMessage, 'TMessage>
+        | RemoveSubscriber of string
+        | Message of 'TMessage
+
+    type Renderer =
+        {
+            Render: Html.Types.Node -> obj
+            Diff: obj -> obj -> obj
+            Patch: Fable.Import.Browser.Node -> obj -> Fable.Import.Browser.Node
+            CreateElement: obj -> Fable.Import.Browser.Node
+        }
+
+    let start renderer app =
+        let renderTree view model handler =
+            view model handler
+            |> renderer.Render
+
+        let startElem =
+            match app.NodeSelector with
+            | None -> document.body
+            | Some sel -> document.body.querySelector(sel) :?> HTMLElement
+
+        MailboxProcessor.Start(fun inbox ->
+            let post message =
+                inbox.Post (Message message)
+
+            let notifySubscribers subs model =
+                subs |> Map.iter (fun key handler -> handler model)
+
+            let rec loop state =
+                async {
+                    match state.Node, state.CurrentTree with
+                    | None,_ ->
+                        let tree = renderTree state.AppState.View state.AppState.Model post
+                        let rootNode = renderer.CreateElement tree
+                        startElem.appendChild(rootNode) |> ignore
+                        return! loop {state with CurrentTree = Some tree; Node = Some rootNode}
+                    | Some rootNode, Some currentTree ->
+                        let! message = inbox.Receive()
+                        match message with
+                        | Message msg ->
+                            ActionReceived msg |> (notifySubscribers state.Subscribers)
+                            let (model', jsCalls) = state.AppState.Update state.AppState.Model msg
+                            let tree = renderTree state.AppState.View model' post
+                            let patches = renderer.Diff currentTree tree
+                            notifySubscribers state.Subscribers (ModelChanged (model', state.AppState.Model))
+                            renderer.Patch rootNode patches |> ignore
+                            jsCalls |> List.iter (fun i -> i())
+                            return! loop {state with AppState = {state.AppState with Model = model'}; CurrentTree = Some tree}
+                        | _ -> return! loop state
+                    | _ -> failwith "Shouldn't happen"
+                }
+            loop app)

--- a/samples/browser/virtualdom/Fable.Import.Virtualdom.fsx
+++ b/samples/browser/virtualdom/Fable.Import.Virtualdom.fsx
@@ -1,0 +1,86 @@
+#r "node_modules/fable-core/Fable.Core.dll"
+#load "Fable.Helpers.Virtualdom.fsx"
+
+open Fable.Core
+open Fable.Import.Browser
+open Fable.Helpers.Virtualdom.Html
+open Fable.Helpers.Virtualdom.App
+
+let failwithjs() = failwith "JS only"
+let [<Import("default","virtual-dom/h")>] h(arg1: string, arg2: obj, arg3: obj[]): obj = failwithjs()
+let [<Import("default","virtual-dom/diff")>] diff(arg1:obj, arg2:obj): obj = failwithjs()
+let [<Import("default","virtual-dom/patch")>] patch(arg1:obj, arg2:obj): Fable.Import.Browser.Node = failwithjs()
+let [<Import("default","virtual-dom/create-element")>] createElement:obj -> Fable.Import.Browser.Node = failwithjs()
+
+[<Emit("String($0)")>]
+let String i :obj= failwith "JS only"
+
+[<Emit("$1.join($0)")>]
+let join sep strs = failwith "JS only"
+
+module Virtualdom =
+    let createTree tag attributes children =
+        let renderEventHandler (eventType, handler) = eventType, handler
+
+        let renderEventBinding binding =
+            match binding with
+            | MouseEventHandler (eventType, handler) -> (eventType, handler :> obj)//renderMouseEventHandler mh
+            | KeyboardEventHandler (eventType, handler) -> (eventType, handler :> obj)
+            | EventHandler (eventType, handler) -> (eventType, handler :> obj)
+            |> renderEventHandler
+
+        let renderAttributes attributes =
+            attributes
+            |> List.map (function
+                            | Attribute.Attribute (k,v) -> Some (k,(v :> obj))
+                            | _ -> None)
+            |> List.choose id
+            |> (function
+                | [] -> None
+                | p -> Some ("attributes", (p |> createObj)))
+
+        let toAttrs attrs =
+            let (attributes, others) = attrs |> List.partition (function Attribute _ -> true | _ -> false)
+            let renderedAttributes = attributes |> renderAttributes
+            let renderedOthers =
+                others
+                |> List.map (function
+                        | EventHandlerBinding binding -> binding |> renderEventBinding
+                        | Style style ->
+                            let v =
+                                style
+                                |> Array.ofList
+                                |> Array.map (fun (k,v) -> k + ":" + v)
+                                |> join ";"
+                                :> obj
+                            "style", v //((style |> Array.ofList |> Array.map (fun (k,v) -> k + ":" + v) |> join ";") :> obj)
+                        | Property (key, value) -> key,(value :> obj)
+                        | Attribute _ -> failwith "Should not happen"
+                    )
+            match renderedAttributes with
+            | Some x -> x::renderedOthers
+            | _ -> renderedOthers
+            |> createObj
+
+        let hAttrs = attributes |> toAttrs
+        let childrenArr = children |> List.toArray
+        h(tag, hAttrs, childrenArr)
+
+    let diff tree1 tree2 = diff(tree1, tree2)
+    let patch node patches = patch(node, patches)
+    let createElement e = createElement(e)
+
+    let rec render node =
+        match node with
+        | Element((tag,attrs), nodes) -> createTree tag attrs (nodes |> List.map render)
+        | VoidElement (tag, attrs) -> createTree tag attrs []
+        | Text str -> String str
+        | WhiteSpace str -> String str
+
+    let renderer =
+        {
+            Render = render
+            Diff = diff
+            Patch = patch
+            CreateElement = createElement
+        }

--- a/samples/browser/virtualdom/fableconfig.json
+++ b/samples/browser/virtualdom/fableconfig.json
@@ -2,9 +2,17 @@
     "module": "commonjs",
     "sourceMaps": false,
     "projFile": "./virtualdom.fsx",
-    "outDir": "out",
+    "outDir": "temp",
     "scripts": {
         "prebuild": "npm install",
-        "postbuild": "node node_modules/webpack/bin/webpack out/virtualdom.js out/bundle.js"
+        "postbuild": "node node_modules/webpack/bin/webpack"
+    },
+    "targets": {
+        "watch": {
+            "watch": true,
+            "scripts": {
+                "postbuild": "node node_modules/webpack/bin/webpack --watch"
+            }
+        }
     }
 }

--- a/samples/browser/virtualdom/index.html
+++ b/samples/browser/virtualdom/index.html
@@ -3,12 +3,13 @@
 <head>
   <script src="http://code.jquery.com/jquery-1.8.0.js"></script>
   <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
+  <link rel="stylesheet" href="node_modules/todomvc-app-css/index.css">
 </head>
 <body>
-	<h1>Virtual DOM Sample</h1>
-
   <!-- [body] -->
-  <div id="test">
+  <div id="counter">
+  </div>
+  <div id="todo">
   </div>
   <!-- [/body] -->
 

--- a/samples/browser/virtualdom/package.json
+++ b/samples/browser/virtualdom/package.json
@@ -12,11 +12,12 @@
   "license": "ISC",
   "dependencies": {
     "core-js": "^2.4.0",
-    "fable-core": "^0.1.9",
+    "fable-core": "0.1.9",
+    "todomvc-app-css": "^2.0.6",
     "virtual-dom": "2.1.1"
   },
   "engines": {
-    "fable": "^0.3.24"
+    "fable": ">=0.2.11"
   },
   "devDependencies": {
     "webpack": "^1.13.1"

--- a/samples/browser/virtualdom/virtualdom.fsx
+++ b/samples/browser/virtualdom/virtualdom.fsx
@@ -1,64 +1,374 @@
 (**
- - title: Super Fable Mario
- - tagline: Mario clone using HTML5 canvas
- - app-style: height:384px; width:512px; margin:20px auto 20px auto; position:relative;
- - intro: Mario clone, based on functional reactive [sample written in
-   Elm](http://debug.elm-lang.org/edit/Mario.elm). The Fable version is using HTML 5
-   canvas to render the background and an `img` tag showing the Mario (using animated GIFs).
-   You can find the [full source code on GitHub](https://github.com/fsprojects/Fable/blob/master/samples/browser/mario/mario.fsx).
-
-   To see how it works, use the left, right and up buttons to play. Our Mario respects
-   no boundaries!
+ - title: The Elm architecture using Fable
+ - tagline: Fable implementation of the Elm architecture
+ - intro: This demo is an implementation of the [Elm architecture](http://guide.elm-lang.org/architecture/)
+ using the same virtual-dom as Elm originally used, https://github.com/Matt-Esch/virtual-dom.
 *)
 (*** hide ***)
+#load "Fable.Helpers.Virtualdom.fsx"
+#load "Fable.Import.Virtualdom.fsx"
 #r "node_modules/fable-core/Fable.Core.dll"
+(**
+##Architecture overview
+
+The beauty of the architecture Elm is using for their application is its
+simplicity. You can read and grasp the whole architecture in a matter of minutes
+here: http://guide.elm-lang.org/architecture/. I won't explain the architecture
+further, instead I will go straight to the examples.
+
+###First example - a simple counter
+*)
 open Fable.Core
+open Fable.Import
 open Fable.Import.Browser
 
-type Style =
-  { border : string }
+open Fable.Helpers.Virtualdom.App
+open Fable.Helpers.Virtualdom.Html
+open Fable.Import.Virtualdom.Virtualdom
 
-let [<Import("default","virtual-dom/h")>] h(arg1: string, arg2: obj, arg3: obj[]): obj = failwith "JS only"
-let [<Import("default","virtual-dom/diff")>] diff:obj = failwith "JS only"
-let [<Import("default","virtual-dom/patch")>] patch:obj = failwith "JS only"
-let [<Import("default","virtual-dom/create-element")>] createElement:obj -> Node = failwith "JS only"
+// model
+type Counter = int
+let initCounter = 0
 
-let hello (count) =
-  h("div", createObj [ "style" ==> { border = "1px solid red" } ], [| string count |])
+(**
+The model for the first example is a simple integer that will act as hour counter.
+We also provide a default value for our counter.
+*)
 
-let tree = hello 42
-let rootNode= createElement tree
-document.body.appendChild(rootNode)
+// Update
+type CounterAction =
+    | Decrement of int
+    | Increment of int
+
+let counterUpdate model action =
+    match action with
+    | Decrement x -> model - x
+    | Increment x -> model + x
+    |> (fun m -> m,[])
+
+(**
+The counter can be incremented or decremented in step of `x`. If you look closely
+the update function return the new model and a list of something. The list of
+something is list of calls js-calls of type `unit->unit` that should be executed
+after this version of the model has been rendered. We will see in a later example
+why this is useful.
+*)
+
+// View
+let counterView model handler =
+    let bgColor =
+        match model with
+        | x when x > 100 -> "red"
+        | x when x < 0 -> "blue"
+        | _ -> "green"
+    div []
+        [
+            div [   Style ["border","1px solid blue"]
+                    onMouseClick (fun x -> handler (Increment 1))
+                    onDblClick (fun x -> handler ((Increment 100)))] [text (string "Increment")]
+            div [ Style ["background-color", bgColor; "color", "white"]] [text (string model)]
+            div [   Style ["border", "1px solid green"; "height", ((string (70 + model)) + "px")]
+                    onMouseClick (fun x -> handler (Decrement 1))
+                    onDblClick (fun x -> handler (Decrement 50))]
+                [text (string "Decrement")]
+        ]
+
+(**
+The `counterView` defines how a model should be rendered. It also takes a `handler`
+that should have a function of the type `'TAction -> unit`, this makes it possible
+to react user actions like we do here on simple mouse actions. The dsl that is used
+here is quite simple and have helper functions for a majority of the standard
+HTML elements. It is trivial to add custom tags if you are missing some tag
+that you would like to use.
+*)
+
+// Start the application
+let counterApp =
+    createApp {Model = initCounter; View = counterView; Update = counterUpdate}
+    |> withStartNode "#counter"
+
+counterApp |> start renderer
+
+(**
+The dsl has been separated from the actual rendering of the dsl, to allow for
+future server side rendering as well. So to get this application started you first
+need to create the application with the `createApp` function. The we pass that
+result to a helper function to specify where in the document it should be rendered,
+default is directly in the body. When we have defined an application we can call
+the `start` function and pass in a `renderer`. We are using the standard `renderer`
+for `virtual-dom.js`, but this separation makes it a little bit easier to change
+to another framework in the future.
+
+That's it, the first application is done and we are ready for example 2.
+
+### Second example - todomvc
+
+To have something to compare to other js-framework, Elm and whatnot a todomvc app
+is in its place. If you don't know what todomvc is check it out here:
+http://todomvc.com/.
+
+We will follow the exact same steps as with the counter example. First implement
+the model, then the update function that to handle actions and lastly the view.
+This example is a little bit longer and have some more features. I'll also show
+how easy it is to store data from the model in the local storage, and that could
+easily be swapped to server side storage without effecting any of the application
+code. Let's start.
+*)
+
+// Todo model
+type Filter =
+    | All
+    | Completed
+    | Active
+
+type Item =
+    {
+        Name: string
+        Done: bool
+        Id: int
+        IsEditing: bool
+    }
+
+type TodoModel =
+    {
+        Items: Item list
+        Input: string
+        Filter: Filter
+    }
+
+(**
+The model is really simple. It consists of a list of items, which you can edit
+and they can be marked as done. You also have a input field and something to
+filter the models with. I use a discriminated union to filter the items, which
+is a nice feature you don't have in standard js.
+*)
+
+// Todo update
+type TodoAction =
+    | AddItem of Item
+    | ChangeInput of string
+    | MarkAsDone of Item
+    | ToggleItem of Item
+    | Destroy of Item
+    | CheckAll
+    | UnCheckAll
+    | SetActiveFilter of Filter
+    | ClearCompleted
+    | EditItem of Item
+    | SaveItem of Item*string
+
+(**
+First we define the actual actions before moving on to the actual update function.
+*)
+
+let todoUpdate model msg =
+    let checkAllWith v =
+        { model with Items = model.Items |> List.map (fun i -> { i with Done = v })}
+
+    let updateItem i model =
+        let items' =
+            model.Items |> List.map (fun i' -> if i'.Id <> i.Id then i' else i)
+        {model with Items = items'}
+
+    let model' =
+        match msg with
+        | AddItem item ->
+            let maxId =
+                if model.Items |> List.isEmpty then 1
+                else
+                    model.Items
+                    |> List.map (fun x -> x.Id)
+                    |> List.max
+            let item' = {item with Id = maxId + 1}
+            {model with Items = item'::model.Items; Input = ""}
+        | ChangeInput v -> {model with Input = v}
+        | MarkAsDone i ->
+            let items' =
+                model.Items |> List.map (fun i' -> if i' <> i then i' else {i with Done = true})
+            {model with Items = items'}
+        | CheckAll -> checkAllWith true
+        | UnCheckAll -> checkAllWith false
+        | Destroy i -> {model with Items = model.Items |> List.filter (fun i' -> i'.Id <> i.Id)}
+        | ToggleItem i -> updateItem {i with Done = not i.Done} model
+        | SetActiveFilter f -> { model with Filter = f }
+        | ClearCompleted -> { model with Items = model.Items |> List.filter (fun i -> not i.Done)}
+        | EditItem i -> updateItem { i with IsEditing = true} model
+        | SaveItem (i,str) -> updateItem { i with Name = str; IsEditing = false} model
+
+    let jsCalls =
+        match msg with
+        | EditItem i -> [fun () -> document.getElementById("item-" + (i.Id.ToString())).focus()]
+        | _ -> []
+    model',jsCalls
+
+(**
+It might seem like a lot of code, but we need to handle all actions and respond
+to them accordingly. I won't go into the detail in all the scenarios, but you
+should pay attention to the step where `jsCalls` is defined. Since we are re-rendering
+the application on changes in the model, or render what has changed as least, we need
+a way to give an input focus if we start edit it. That is when the list of js
+function calls come in handy. So the update function returns the new model a
+long side a list of js function calls if we need to do something after rendering,
+and that is something we need to do when we start edit an item, we want to give
+that item focus.
+
+With this done all we need is to define the view.
+*)
+
+// Todo view
+let filterToTextAndUrl = function
+    | All -> "All", ""
+    | Completed -> "Completed", "completed"
+    | Active -> "Active", "active"
+
+let filter handler activeFilter f =
+    let linkClass = if f = activeFilter then "selected" else ""
+    let fText,url = f |> filterToTextAndUrl
+    li
+        [ onMouseClick (fun _ -> SetActiveFilter f |> handler)]
+        [ a
+            [ attribute "href" ("#/" + url); attribute "class" linkClass ]
+            [ text fText] ]
+
+let filters model handler =
+    ul
+        [ attribute "class" "filters" ]
+        ([ All; Active; Completed ] |> List.map (filter handler model.Filter))
+
+let todoFooter model handler =
+    let clearVisibility =
+        if model.Items |> List.exists (fun i -> i.Done)
+        then ""
+        else "none"
+    let activeCount = model.Items |> List.filter (fun i -> not i.Done) |> List.length |> string
+    footer
+        [   attribute "class" "footer"; Style ["display","block"]]
+        [   span
+                [ attribute "class" "todo-count" ]
+                [   strong [] [text activeCount]
+                    text " items left" ]
+            (filters model handler)
+            button
+                [   attribute "class" "clear-completed"
+                    Style [ "display", clearVisibility ]
+                    onMouseClick (fun _ -> handler ClearCompleted)]
+                [ text "Clear completed" ] ]
 
 
-(*
-// 1: Create a function that declares what the DOM should look like
-function render(count)  {
-    return h('div', {
-        style: {
-            textAlign: 'center',
-            lineHeight: (100 + count) + 'px',
-            border: '1px solid red',
-            width: (100 + count) + 'px',
-            height: (100 + count) + 'px'
-        }
-    }, [String(count)]);
-}
+let todoHeader model handler =
+    header
+        [attribute "class" "header"]
+        [   h1 [] [text "todos"]
+            input [ attribute "class" "new-todo"
+                    property "placeholder" "What needs to be done??"
+                    property "value" model
+                    onKeydown (fun x ->
+                        if x.code = "Enter"
+                        then handler (AddItem {Name = model; Id = 0; Done = false; IsEditing = false})
+                        )
+                    onKeyup (fun x -> handler (ChangeInput (x?target?value :?> string))) ]]
 
-// 2: Initialise the document
-var count = 0;      // We need some app data. Here we just store a count.
+let listItem handler item =
+    let itemChecked = if item.Done then "true" else ""
+    let editClass = if item.IsEditing then "editing" else ""
+    li [ attribute "class" ((if item.Done then "completed " else " ") + editClass)]
+       [ div [  attribute "class" "view"
+                onDblClick (fun x -> printfn "%A" x; EditItem item |> handler) ]
+             [ input [  property "className" "toggle"
+                        property "type" "checkbox"
+                        property "checked" itemChecked
+                        onMouseClick (fun e -> handler (ToggleItem item)) ]
+               label [] [ text item.Name ]
+               button [ attribute "class" "destroy"
+                        onMouseClick (fun e -> handler (Destroy item)) ] [] ]
+         input [ attribute "class" "edit"
+                 attribute "value" item.Name
+                 property "id" ("item-"+item.Id.ToString())
+                 onBlur (fun e -> SaveItem (item, (e?target?value :?> string)) |> handler) ] ]
 
-var tree = render(count);               // We need an initial tree
-var rootNode = createElement(tree);     // Create an initial root DOM node ...
-document.body.appendChild(rootNode);    // ... and it should be in the document
+let itemList handler items activeFilter =
+    let filterItems i =
+        match activeFilter with
+        | All -> true
+        | Completed -> i.Done
+        | Active -> not i.Done
 
-// 3: Wire up the update logic
-setInterval(function () {
-      count++;
+    ul [attribute "class" "todo-list" ]
+       (items |> List.filter filterItems |> List.map (listItem handler))
 
-      var newTree = render(count);
-      var patches = diff(tree, newTree);
-      rootNode = patch(rootNode, patches);
-      tree = newTree;
-}, 1000);
+let todoMain model handler =
+    let items = model.Items
+    let allChecked = items |> List.exists (fun i -> not i.Done)
+    section [  attribute "class" "main"
+               Style [ "style", "block" ] ]
+            [   input [ property "id" "toggle-all"
+                        attribute "class" "toggle-all"
+                        property "type" "checkbox"
+                        property "checked" (if not allChecked then "true" else "")
+                        onMouseClick (fun e ->
+                                    if allChecked
+                                    then handler CheckAll
+                                    else handler UnCheckAll) ]
+                label [ attribute "for" "toggle-all" ]
+                      [ text "Mark all as complete" ]
+                (itemList handler items model.Filter) ]
+
+let todoView m handler =
+    section
+        [attribute "class" "todoapp"]
+        ((todoHeader m.Input handler)::(if m.Items |> List.isEmpty
+                then []
+                else [  (todoMain m handler)
+                        (todoFooter m handler) ] ))
+
+(**
+This view is more complex than the first example, but it also show how easy it is
+to split a view up into pieces and then combine them together to form a whole. This
+makes it quite easy to re-use parts in different views.
+
+Before this is done, there are one hidden gem that is worth knowing, and it will
+be showed with two examples. We will add local storage support of the items and a
+logger of all the actions and model changes. First we need a helper for the storage.
+*)
+
+// Storage
+module Storage =
+    let private STORAGE_KEY = "vdom-storage"
+    open Microsoft.FSharp.Core
+    let fetch<'T> (): 'T [] =
+        Browser.localStorage.getItem(STORAGE_KEY)
+        |> function null -> "[]" | x -> unbox x
+        |> JS.JSON.parse |> unbox
+
+    let save<'T> (todos: 'T []) =
+        Browser.localStorage.setItem(STORAGE_KEY, JS.JSON.stringify todos)
+
+(**
+The module above is a simple helper to store a list of items in local storage
+of the browser, now let's add it and support for logging.
+*)
+
+open Storage
+let initList = fetch<Item>() |> List.ofArray
+let initModel = {Filter = All; Items = initList; Input = ""}
+
+let todoApp =
+    createApp {Model = initModel; View = todoView; Update = todoUpdate}
+    |> (withSubscriber "storagesub" (function
+            | ModelChanged (newModel,old) -> save (newModel.Items |> Array.ofList)
+            | _ -> ()))
+    |> (withSubscriber "modellogger" (printfn "%A"))
+    |> withStartNode "#todo"
+
+todoApp |> start renderer
+
+(**
+First we initiate the model by checking the local storage if there are any items
+there. The to add support for local storage we add a subscriber. A subscriber is
+a function that handles `AppEvents`, they can be `ModelChanged` or `ActionReceived`.
+For the storage we are only interested in model changes, so that is what we act on
+and store the list of items in the local storage when the model was changed. For
+the logger we just logs everything.
+
+We also start the application on the `#todo` element in the document.
 *)

--- a/samples/browser/virtualdom/virtualdom.fsx
+++ b/samples/browser/virtualdom/virtualdom.fsx
@@ -55,7 +55,7 @@ why this is useful.
 *)
 
 // View
-let counterView model handler =
+let counterView handler model =
     let bgColor =
         match model with
         | x when x > 100 -> "red"
@@ -313,13 +313,13 @@ let todoMain model handler =
                       [ text "Mark all as complete" ]
                 (itemList handler items model.Filter) ]
 
-let todoView m handler =
+let todoView handler model =
     section
         [attribute "class" "todoapp"]
-        ((todoHeader m.Input handler)::(if m.Items |> List.isEmpty
+        ((todoHeader model.Input handler)::(if model.Items |> List.isEmpty
                 then []
-                else [  (todoMain m handler)
-                        (todoFooter m handler) ] ))
+                else [  (todoMain model handler)
+                        (todoFooter model handler) ] ))
 
 (**
 This view is more complex than the first example, but it also show how easy it is

--- a/samples/browser/virtualdom/webpack.config.js
+++ b/samples/browser/virtualdom/webpack.config.js
@@ -1,0 +1,14 @@
+var path = require("path");
+var webpack = require("webpack");
+var cfg = {
+  devtool: "source-map",
+  entry: "./temp/virtualdom.js",
+  output: {
+    path: path.join(__dirname, "out"),
+    filename: "bundle.js"
+  },
+  module: {
+  }
+};
+//node node_modules/webpack/bin/webpack out/virtualdom.js out/bundle.js"
+module.exports = cfg;


### PR DESCRIPTION
The Elm architecture implemented in F# and Fable. It is probably a lot more to add to this, performance wise and maybe in the API as well. I do think this is a great starting point and something to build on.

For this PR to be complete the sample need to render two divs with specific id right before each example. Didn't get the sample to render at all, so didn't manage to render a div with the markdown, if event possible. It is possible to try the samples out with just running fable and open the index.html file. The sample contains a simple counter that also modifies the html and an implementation of todomvc.

I haven't had the time to proof read the sample text and describe everything in detail. Hopefully it is good enough anyway.