### PR TITLE
Add withInit function to allow bootstrapping app on load

### DIFF
--- a/import/virtualdom/Fable.Helpers.Virtualdom.fs
+++ b/import/virtualdom/Fable.Helpers.Virtualdom.fs
@@ -338,6 +338,7 @@ module App =
     type App<'TModel, 'TMessage> =
         {
             AppState: AppState<'TModel, 'TMessage>
+            Init : ('TMessage -> unit) -> unit
             JsCalls: (unit -> unit) list
             Node: Node option
             CurrentTree: obj option
@@ -366,6 +367,7 @@ module App =
     let createApp appState =
         {
             AppState = appState
+            Init = (fun _ -> ())
             JsCalls = []
             Node = None
             CurrentTree = None
@@ -375,6 +377,7 @@ module App =
         }
 
     let withStartNode selector app = { app with NodeSelector = Some selector }
+    let withInit init app = { app with Init = init }
     let withSubscriber subscriberId subscriber app =
         let subsribers = app.Subscribers |> Map.add subscriberId subscriber
         { app with Subscribers = subsribers }
@@ -418,6 +421,7 @@ module App =
                         let tree = renderTree state.AppState.View post state.AppState.Model
                         let rootNode = renderer.CreateElement tree
                         startElem.appendChild(rootNode) |> ignore
+                        state.Init post
                         return! loop {state with CurrentTree = Some tree; Node = Some rootNode}
                     | Some rootNode, Some currentTree ->
                         let! message = inbox.Receive()


### PR DESCRIPTION
It is similar to what can be done with ELM: http://guide.elm-lang.org/architecture/effects/
In ELM, basically, you use App.beginnerProgram that take only a Model (as Fable virtualdom for now), but to add "effects", you use App.program that take an init (Model, Cmd Msg) tuple (ELM example: http://elm-lang.org/examples/http).

I thought it would be better integrated with a "withInit" function applied on App type in Fable virtualdom implementation.