### PR TITLE
Remove [was Bring back] AllAndCore target

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -330,7 +330,6 @@ Target "PublishDocs" (fun _ ->
 )
 
 Target "All" ignore
-Target "AllAndCore" ignore
 
 // Build order
 "Clean"


### PR DESCRIPTION
[This change](https://github.com/fsprojects/Fable/commit/37b4e195f39a3b5af32ff6afe2674cfbb906ee58#diff-6074983490330a0aac1bd23c958232d7) broke the `AllAndCore` target that I added (it removed the lines that specify its requirements, so it is no-op). Was that intentional?

I think it is good idea to have a target that builds everything - plus I really need it so that I can reference latest Fable using Paket's git dependencies. Please please please :pray: 