### PR TITLE
Add trampoline to avoid StackOverflow in asyncs

### DIFF
--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -3552,7 +3552,7 @@ export interface CancellationToken {
   isCancelled: boolean;
 }
 
-const maxTrampolineCallCount = 1000;
+const maxTrampolineCallCount = 2000;
 
 export class Trampoline {
   private callCount = 0;
@@ -3582,7 +3582,13 @@ const AsyncImpl = {
       if (ctx.cancelToken.isCancelled)
         ctx.onCancel("cancelled");
       else if (ctx.trampoline.incrementAndCheck()) 
-        ctx.trampoline.hijack(() => f(ctx))
+        ctx.trampoline.hijack(() => {
+          try {
+            return f(ctx);
+          } catch(err) {
+            ctx.onError(err);
+          }
+        });
       else
         try {
           return f(ctx);


### PR DESCRIPTION
I'm using `async` too much in Fable - when you have too many `async` calls that are not actually doing anything asynchronously, you get a StackOverflow exception pretty soon.

This can be avoided by counting (guessing) how deep we are and when we are too deep, resuming the continuation in a new context with empty stack - e.g. using `setTimeout`. This is what this PR is doing.

### Potential issues

 - Is `setTimeout(f, 0)` going to work on server-side JS? (We are already using it in `Async.Sleep`, so if this is an issue, we should probably figure out what to do in `Async.Sleep` too)

 - Is 1000 the right number? It solved the problems I had in Chrome in the web context, but I really do not have idea how much is right in general. I guess we can tweak this as needed.

 - When you have async operations in your code, this change will still use `setTimeout`  every 1000 calls, because we do not know when async operation happens - this would be somehow specified by the user (when they await something).

### Alternative options

Do not do anything - we can just tell the users they have to insert `do! Async.Sleep(0)` when they run lots of async operations that are not in fact asynchronous.