### PR TITLE
Generate d.ts declarations

### DIFF
--- a/src/fable/Fable.Client.Node/Main.fs
+++ b/src/fable/Fable.Client.Node/Main.fs
@@ -148,6 +148,7 @@ let printFile =
     let jsonSettings =
         JsonSerializerSettings(
             Converters=[|Json.ErasedUnionConverter()|],
+            NullValueHandling=NullValueHandling.Ignore,
             StringEscapeHandling=StringEscapeHandling.EscapeNonAscii)
     fun (file: AST.Babel.Program) ->
         JsonConvert.SerializeObject (file, jsonSettings)

--- a/src/fable/Fable.Client.Node/Main.fs
+++ b/src/fable/Fable.Client.Node/Main.fs
@@ -58,7 +58,8 @@ let readOptions argv =
         msbuild = def opts "msbuild" [] (li id)
         refs = Map(def opts "refs" [] (li (fun (x: string) ->
             let xs = x.Split('=') in xs.[0], xs.[1])))
-        extra = Map.empty // TODO: Read extra options
+        extra = Map(def opts "extra" [] (li (fun (x: string) ->
+            let xs = x.Split('=') in xs.[0], xs.[1])))
     }
 
 let loadPlugins (pluginPaths: string list) =

--- a/src/fable/Fable.Client.Node/Main.fs
+++ b/src/fable/Fable.Client.Node/Main.fs
@@ -53,6 +53,7 @@ let readOptions argv =
         watch = def opts "watch" false (un bool.Parse)
         clamp = def opts "clamp" false (un bool.Parse)
         copyExt = def opts "copyExt" false (un bool.Parse)
+        declaration = def opts "declaration" false (un bool.Parse)
         symbols = def opts "symbols" [] (li id)
         plugins = def opts "plugins" [] (li id)
         msbuild = def opts "msbuild" [] (li id)

--- a/src/fable/Fable.Client.Node/js/fable.js
+++ b/src/fable/Fable.Client.Node/js/fable.js
@@ -38,17 +38,22 @@ var optionDefinitions = [
   { name: 'refs', multiple: true, description: "Specify dll or project references in `Reference=js/import/path` format (e.g. `MyLib=../lib`)." },
   { name: 'msbuild', mutiple: true, description: "Pass MSBuild arguments like `Configuration=Release`." },
   { name: 'clamp', type: Boolean, description: "Compile unsigned byte arrays as Uint8ClampedArray." },
-  { name: 'copyExt', type: Boolean, defaultValue: true, description: "Copy external files into `fable_external` folder (true by default)." },
+  { name: 'copyExt', type: Boolean, description: "Copy external files into `fable_external` folder (true by default)." },
   { name: 'coreLib', description: "In some cases, you may need to pass a different route to the core library, like `--coreLib fable-core/es2015`." },
   { name: 'verbose', description: "Print more information about the compilation process." },
   { name: 'target', alias: 't', description: "Use options from a specific target in `fableconfig.json`." },
   { name: 'debug', alias: 'd', description: "Shortcut for `--target debug`." },
   { name: 'production', alias: 'p', description: "Shortcut for `--target production`." },
+  { name: 'declaration', type: Boolean, description: "[Experimental] Generates corresponding ‘.d.ts’ file." },
+  { name: 'extra', multiple: true, description: "Custom options in `Key=Value` format." },
   { name: 'help', alias: 'h', description: "Display usage guide." }
 ];
 
-var fableBin = path.resolve(__dirname, "bin/Fable.Client.Node.exe");
 var fableConfig = "fableconfig.json";
+var fableBin = path.resolve(__dirname, "bin/Fable.Client.Node.exe");
+var fableBinOptions = new Set([
+    "projFile", "coreLib", "symbols", "plugins", "msbuild", "refs", "watch", "clamp", "copyExt", "extra"
+]);
 
 // Custom plugin to remove `null;` statements (e.g. at the end of constructors)
 var removeNullStatements = {
@@ -109,6 +114,8 @@ var transformMacroExpressions = {
 };
 
 var babelPlugins = [
+    // Strip flow type annotations and declarations
+    require("babel-plugin-transform-flow-strip-types"),
     transformMacroExpressions,
     // "transform-es2015-block-scoping", // This creates too many function wrappers
     removeNullStatements,
@@ -141,23 +148,22 @@ function ensureDirExists(dir, cont) {
 
 function babelifyToFile(babelAst, opts) {
     var projDir = path.dirname(path.resolve(path.join(cfgDir, opts.projFile)));
-    var targetFile = path.join(opts.outDir, path.relative(projDir, path.resolve(babelAst.fileName)));
-    targetFile = targetFile.replace(path.extname(babelAst.fileName), ".js")
-
-    var fsCode = null, babelOpts = {};
-    if (opts.sourceMaps && babelAst.originalFileName) {
+    var targetFile = path.join(path.resolve(opts.outDir), path.relative(projDir, path.resolve(babelAst.fileName)))
+                         .replace(/\\/g, '/')
+                         .replace(path.extname(babelAst.fileName), ".js");
+    var fsCode = null,
         babelOpts = {
-            plugins: babelPlugins,
-            sourceMaps: opts.sourceMaps,
-            sourceMapTarget: path.basename(targetFile),
-            sourceFileName: path.relative(path.dirname(targetFile),
-                                babelAst.originalFileName).replace(/\\/g, '/')
+            filename: targetFile,
+            sourceRoot: path.resolve(opts.outDir),
+            plugins: babelPlugins
         };
+    if (opts.sourceMaps && babelAst.originalFileName) {
+        babelOpts.sourceMaps = opts.sourceMaps,
+        babelOpts.sourceMapTarget = path.basename(targetFile),
+        babelOpts.sourceFileName = path.relative(path.dirname(targetFile),
+            babelAst.originalFileName).replace(/\\/g, '/')
         // The F# code is only necessary when generating source maps
         fsCode = fs.readFileSync(babelAst.originalFileName);
-    }
-    else {
-        babelOpts = { plugins: babelPlugins }
     }
 
     var parsed = babel.transformFromAst(babelAst, fsCode, babelOpts);
@@ -322,15 +328,48 @@ function addModulePlugin(opts, babelPlugins) {
 }
 
 function build(opts) {
+    if (opts.declaration) {
+        babelPlugins.splice(0,0,[
+            require("babel-dts-generator"),
+            {
+                "packageName": "",
+                "typings": path.resolve(opts.outDir),
+                "suppressAmbientDeclaration": true,
+                "ignoreEmptyInterfaces": false
+            }
+        ]);
+    }
+
     // ECMAScript target
     if (opts.ecma != "es2015" && opts.ecma != "es6") {
         babelPlugins = babelPlugins.concat(babelPlugins_es2015);
     }
     
     // Extra Babel plugins
+    function resolveBabelPlugin(id) {
+        var nodeModulesDir = path.join(path.resolve(cfgDir), "node_modules");
+        if (fs.existsSync(path.join(nodeModulesDir, id))) {
+            return path.join(nodeModulesDir, id);
+        }
+        else {
+            return path.join(nodeModulesDir, "babel-plugin-" + id);
+        }
+    }
+
     if (opts.babelPlugins) {
-        (Array.isArray(opts.babelPlugins) ? opts.babelPlugins : [opts.babelPlugins]).forEach(function (x) {
-            babelPlugins.push(require(path.join(path.resolve(cfgDir), "node_modules", "babel-plugin-" + x)));
+        (Array.isArray(opts.babelPlugins) ? opts.babelPlugins : [opts.babelPlugins]).forEach(function (plugin) {
+            if (typeof plugin === "string") {
+                babelPlugins.push(resolveBabelPlugin(plugin));
+            }
+            else if (Array.isArray(plugin)) { // plugin id + config obj
+                babelPlugins.push([
+                    resolveBabelPlugin(plugin[0]),
+                    plugin[1]
+                ]);
+            }
+            else {
+                throw "Babel plugin must be a string or a [string, object] tuple";
+            }
         });
     }
 
@@ -349,10 +388,12 @@ function build(opts) {
     var fableCmd = "mono", fableCmdArgs = [wrapInQuotes(fableBin)];
 
     for (var k in opts) {
-        if (Array.isArray(opts[k]))
-            opts[k].forEach(function (v) { fableCmdArgs.push("--" + k, wrapInQuotes(v)) })
-        else if (typeof opts[k] !== "object")
-            fableCmdArgs.push("--" + k, wrapInQuotes(opts[k]));
+        if (fableBinOptions.has(k)) {
+            if (Array.isArray(opts[k]))
+                opts[k].forEach(function (v) { fableCmdArgs.push("--" + k, wrapInQuotes(v)) })
+            else if (typeof opts[k] !== "object")
+                fableCmdArgs.push("--" + k, wrapInQuotes(opts[k]));
+        }
     }
 
     if (process.platform === "win32") {
@@ -458,6 +499,7 @@ try {
     }
 
     // Default values
+    opts.copyExt = "copyExt" in opts ? opts.copyExt : true;
     opts.outDir = opts.outDir ? (path.join(cfgDir, opts.outDir)) : path.dirname(path.join(cfgDir, opts.projFile));
     opts.ecma = opts.ecma || "es5";
     if (typeof opts.refs == "object" && !Array.isArray(opts.refs)) {

--- a/src/fable/Fable.Client.Node/js/fable.js
+++ b/src/fable/Fable.Client.Node/js/fable.js
@@ -52,7 +52,8 @@ var optionDefinitions = [
 var fableConfig = "fableconfig.json";
 var fableBin = path.resolve(__dirname, "bin/Fable.Client.Node.exe");
 var fableBinOptions = new Set([
-    "projFile", "coreLib", "symbols", "plugins", "msbuild", "refs", "watch", "clamp", "copyExt", "extra"
+    "projFile", "coreLib", "symbols", "plugins", "msbuild",
+    "refs", "watch", "clamp", "copyExt", "extra", "declaration"
 ]);
 
 // Custom plugin to remove `null;` statements (e.g. at the end of constructors)
@@ -114,8 +115,6 @@ var transformMacroExpressions = {
 };
 
 var babelPlugins = [
-    // Strip flow type annotations and declarations
-    require("babel-plugin-transform-flow-strip-types"),
     transformMacroExpressions,
     // "transform-es2015-block-scoping", // This creates too many function wrappers
     removeNullStatements,
@@ -329,15 +328,16 @@ function addModulePlugin(opts, babelPlugins) {
 
 function build(opts) {
     if (opts.declaration) {
-        babelPlugins.splice(0,0,[
-            require("babel-dts-generator"),
+        babelPlugins.splice(0,0,
+            [require("babel-dts-generator"),
             {
                 "packageName": "",
                 "typings": path.resolve(opts.outDir),
                 "suppressAmbientDeclaration": true,
                 "ignoreEmptyInterfaces": false
-            }
-        ]);
+            }],
+            require("babel-plugin-transform-flow-strip-types")
+        );
     }
 
     // ECMAScript target

--- a/src/fable/Fable.Client.Node/js/package.json
+++ b/src/fable/Fable.Client.Node/js/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "babel-core": "^6.10.4",
+    "babel-dts-generator": "^0.6.2",
     "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
     "babel-plugin-transform-es2015-block-scoping": "^6.10.1",
     "babel-plugin-transform-es2015-classes": "^6.9.0",
@@ -21,6 +22,7 @@
     "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
     "babel-plugin-transform-es2015-spread": "^6.8.0",
     "babel-plugin-transform-es5-property-mutators": "^6.8.0",
+    "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-template": "^6.9.0",
     "command-line-args": "^3.0.0",
     "command-line-usage": "^3.0.2",

--- a/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
@@ -377,11 +377,16 @@ module Types =
             None
 
     and makeEntity (com: IFableCompiler) (tdef: FSharpEntity) =
+        let makeFields (tdef: FSharpEntity) =
+            tdef.FSharpFields
+            // It's ok to use an empty context here, because we don't need to resolve generic params
+            |> Seq.map (fun x -> x.Name, makeType com Context.Empty x.FieldType)
+            |> Seq.toList
         let kind =
             if tdef.IsInterface then Fable.Interface
-            elif tdef.IsFSharpRecord then Fable.Record
             elif tdef.IsFSharpUnion then Fable.Union
-            elif tdef.IsFSharpExceptionDeclaration then Fable.Exception
+            elif tdef.IsFSharpRecord then makeFields tdef |> Fable.Record
+            elif tdef.IsFSharpExceptionDeclaration then makeFields tdef |> Fable.Exception
             elif tdef.IsFSharpModule || tdef.IsNamespace then Fable.Module
             else Fable.Class (getBaseClass com tdef)
         let genParams =

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -625,8 +625,9 @@ type private DeclInfo(init: Fable.Declaration list) =
     let hasIgnoredAtt atts =
         atts |> tryFindAtt (Naming.ignoredAtts.Contains) |> Option.isSome
     member self.IsIgnoredEntity (ent: FSharpEntity) =
-        ent.IsFSharpAbbreviation || ent.IsInterface
-        || (hasIgnoredAtt ent.Attributes) || isAttributeEntity ent
+        ent.IsFSharpAbbreviation
+        || isAttributeEntity ent
+        || (hasIgnoredAtt ent.Attributes)
     /// Is compiler generated (CompareTo...) or belongs to ignored entity?
     /// (remember F# compiler puts class methods in enclosing modules)
     member self.IsIgnoredMethod (meth: FSharpMemberOrFunctionOrValue) =

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -1428,3 +1428,13 @@ let tryReplace (com: ICompiler) (info: Fable.ApplyInfo) =
     with
     | ex -> failwithf "Cannot replace %s.%s: %s"
                 info.ownerFullName info.methodName ex.Message
+
+let coreLibMappedTypes =
+    Map [
+        fsharp + "Control.FSharpAsync" => "Async"
+        fsharp + "Collections.FSharpSet" => "Set"
+        fsharp + "Collections.FSharpMap" => "Map"
+        fsharp + "Collections.FSharpList" => "List"
+        fsharp + "Core.FSharpChoice" => "Choice"
+    ]
+

--- a/src/fable/Fable.Core/AST/AST.Babel.fs
+++ b/src/fable/Fable.Core/AST/AST.Babel.fs
@@ -27,6 +27,27 @@ type Node(typ, ?loc) =
 /// A module import or export declaration.
 [<AbstractClass>] type ModuleDeclaration(typ, ?loc) = inherit Node(typ, ?loc = loc)
 
+[<AbstractClass>]
+type TypeAnnotationInfo(typ) =
+    member x.``type``: string = typ
+
+type TypeAnnotation(typeInfo) =
+    member x.``type`` = "TypeAnnotation"
+    member x.typeAnnotation: TypeAnnotationInfo = typeInfo
+
+// TODO: TypeParameter can also have `variance` and `bound` properties
+type TypeParameter(name) =
+    member x.``type`` = "TypeParameter"
+    member x.name: string = name
+
+type TypeParameterDeclaration(typeParams) =
+    member x.``type`` = "TypeParameterDeclaration"
+    member x.``params``: TypeParameter list = typeParams
+
+type TypeParameterInstantiation(typeParams) =
+    member x.``type`` = "TypeParameterInstantiation"
+    member x.``params``: TypeAnnotationInfo list = typeParams
+
 type Pattern = interface end
 
 /// Placeholder, doesn't belong to Babel specs
@@ -58,9 +79,10 @@ type TaggedTemplateExpression(tag, quasi, ?loc) =
 
 (** ##Identifier *)
 /// Note that an identifier may be an expression or a destructuring pattern.
-type Identifier(name, ?loc) =
+type Identifier(name, ?typeAnnotation, ?loc) =
     inherit Expression("Identifier", ?loc = loc)
     member x.name: string = name
+    member x.typeAnnotation: TypeAnnotation option = typeAnnotation
     interface Pattern
     override x.ToString() = x.name
 
@@ -259,13 +281,16 @@ type ArrowFunctionExpression(arguments, body, ?async, ?loc) =
     member x.body: U2<BlockStatement, Expression> = body
     member x.async: bool = defaultArg async false
         
-type FunctionExpression(arguments, body, ?generator, ?async, ?id, ?loc) =
+type FunctionExpression(arguments, body, ?generator, ?async,
+                        ?id, ?returnType, ?typeParams, ?loc) =
     inherit Expression("FunctionExpression", ?loc = loc)
     member x.id: Identifier option = id
     member x.``params``: Pattern list = arguments
     member x.body: BlockStatement = body
     member x.generator: bool = defaultArg generator false
     member x.async: bool = defaultArg async false
+    member x.typeParameters: TypeParameterDeclaration option = typeParams
+    member x.returnType: TypeAnnotation option = returnType
     
 /// e.g., x = do { var t = f(); t * t + 1 };
 /// http://wiki.ecmascript.org/doku.php?id=strawman:do_expressions
@@ -501,19 +526,21 @@ type ClassBody(body, ?loc) =
     inherit Node("ClassBody", ?loc = loc)
     member x.body: U2<ClassMethod, ClassProperty> list = body
 
-type ClassDeclaration(body, id, ?super, ?loc) =
+type ClassDeclaration(body, id, ?super, ?typeParams, ?loc) =
     inherit Declaration("ClassDeclaration", ?loc = loc)
     member x.body: ClassBody = body
     member x.id: Identifier = id
     member x.superClass: Expression option = super
+    member x.typeParameters: TypeParameterDeclaration option = typeParams
     // member x.decorators: Decorator list = defaultArg decorators []
 
 /// Anonymous class: e.g., var myClass = class { }
-type ClassExpression(body, ?id, ?super, ?loc) =
+type ClassExpression(body, ?id, ?super, ?typeParams, ?loc) =
     inherit Expression("ClassExpression", ?loc = loc)
     member x.body: ClassBody = body
     member x.id: Identifier option = id    
     member x.superClass: Expression option = super
+    member x.typeParameters: TypeParameterDeclaration option = typeParams
     // member x.decorators: Decorator list = defaultArg decorators []
 
 // type MetaProperty(meta, property, ?loc) =
@@ -578,3 +605,67 @@ type ExportDefaultDeclaration(declaration, ?loc) =
 type ExportAllDeclaration(source, ?loc) =
     inherit ModuleDeclaration("ExportAllDeclaration", ?loc = loc)
     member x.source: Literal = source
+
+(** ##Type Annotations *)
+
+type StringTypeAnnotation() =
+    inherit TypeAnnotationInfo("StringTypeAnnotation")
+
+type NumberTypeAnnotation() =
+    inherit TypeAnnotationInfo("NumberTypeAnnotation")
+
+type BooleanTypeAnnotation() =
+    inherit TypeAnnotationInfo("BooleanTypeAnnotation")
+
+type AnyTypeAnnotation() =
+    inherit TypeAnnotationInfo("AnyTypeAnnotation")
+
+type VoidTypeAnnotation() =
+    inherit TypeAnnotationInfo("VoidTypeAnnotation")
+
+type TupleTypeAnnotation(types) =
+    inherit TypeAnnotationInfo("TupleTypeAnnotation")
+    member x.types: TypeAnnotationInfo list = types
+
+type FunctionTypeParam(name, typeInfo, ?optional) =
+    member x.``type`` = "FunctionTypeParam"
+    member x.name: Identifier = name
+    member x.typeAnnotation: TypeAnnotationInfo = typeInfo
+    member x.optional = defaultArg optional false
+
+type FunctionTypeAnnotation(args, returnType, ?rest) =
+    inherit TypeAnnotationInfo("FunctionTypeAnnotation")
+    member x.``params``: FunctionTypeParam list = args
+    member x.rest: FunctionTypeParam option = rest
+    member x.returnType: TypeAnnotationInfo = returnType
+
+type GenericTypeAnnotation(id, ?typeParams) =
+    inherit TypeAnnotationInfo("GenericTypeAnnotation")
+    member x.id: Identifier = id
+    member x.typeParameters: TypeParameterInstantiation option = typeParams
+
+type ObjectTypeProperty(key, value, ?isStatic, ?isOptional) =
+    inherit Node("ObjectTypeProperty")
+    member x.key: Identifier = key
+    member x.value: TypeAnnotationInfo = value
+    member x.``static``: bool = defaultArg isStatic false
+    member x.optional: bool = defaultArg isOptional false
+
+type ObjectTypeAnnotation(properties) =
+    inherit TypeAnnotationInfo("ObjectTypeAnnotation")
+    member x.properties: obj list = []
+    // member x.callProperties
+    // member x.indexers
+
+type InterfaceExtends(id, ?typeParams) =
+    member x.``type`` = "InterfaceExtends"
+    member x.id: Identifier = id
+    member x.typeParameters: TypeParameterInstantiation option = typeParams
+
+type InterfaceDeclaration(body, id, extends, ?typeParams, ?loc) =
+    inherit Declaration("InterfaceDeclaration", ?loc = loc)
+    member x.body: ObjectTypeAnnotation = body
+    member x.id: Identifier = id
+    member x.extends: InterfaceExtends list = extends
+    member x.typeParameters: TypeParameterDeclaration option = typeParams
+    // member x.mixins

--- a/src/fable/Fable.Core/AST/AST.Babel.fs
+++ b/src/fable/Fable.Core/AST/AST.Babel.fs
@@ -526,10 +526,11 @@ type ClassMethod(kind, key, args, body, computed, ``static``,
 /// ES Class Fields & Static Properties
 /// https://github.com/jeffmo/es-class-fields-and-static-properties
 /// e.g, class MyClass { static myStaticProp = 5; myProp /* = 10 */; }
-type ClassProperty(key, value, ?loc) =
+type ClassProperty(key, ?value, ?typeAnnotation, ?loc) =
     inherit Node("ClassProperty", ?loc = loc)
     member x.key: Identifier = key
-    member x.value: Expression = value
+    member x.value: Expression option = value
+    member x.typeAnnotation: TypeAnnotation option = typeAnnotation
 
 type ClassBody(body, ?loc) =
     inherit Node("ClassBody", ?loc = loc)

--- a/src/fable/Fable.Core/AST/AST.Babel.fs
+++ b/src/fable/Fable.Core/AST/AST.Babel.fs
@@ -255,13 +255,15 @@ type ForOfStatement(left, right, body, ?loc) =
     member x.right: Expression = right
 
 /// A function declaration. Note that id cannot be null.
-type FunctionDeclaration(id, arguments, body, ?returnType, ?generator, ?async, ?loc) =
+type FunctionDeclaration(id, arguments, body, ?generator, ?async,
+                         ?returnType, ?typeParams, ?loc) =
     inherit Declaration("FunctionDeclaration", ?loc = loc)
     member x.id: Identifier = id
     member x.``params``: Pattern list = arguments
     member x.body: BlockStatement = body
     member x.generator = defaultArg generator false
     member x.async = defaultArg async false
+    member x.typeParameters: TypeParameterDeclaration option = typeParams    
     member x.returnType: TypeAnnotation option = returnType
 
 (** ##Expressions *)
@@ -341,16 +343,18 @@ type ObjectProperty(key, value, ?shorthand, ?computed, ?loc) =
 
 type ObjectMethodKind = ObjectGetter | ObjectSetter | ObjectMeth
 
-type ObjectMethod(kind, key, arguments, body, ?returnType, ?computed, ?generator, ?async, ?loc) =
+type ObjectMethod(kind, key, arguments, body, ?computed, ?generator,
+                  ?async, ?returnType, ?typeParams, ?loc) =
     inherit ObjectMember("ObjectMethod", key, ?computed=computed, ?loc=loc)
     member x.kind = match kind with ObjectGetter -> "get"
                                   | ObjectSetter -> "set"
                                   | ObjectMeth -> "method"
     member x.``params``: Pattern list = arguments
     member x.body: BlockStatement = body
-    member x.returnType: TypeAnnotation option = returnType
     member x.generator: bool = defaultArg generator false
     member x.async: bool = defaultArg async false
+    member x.returnType: TypeAnnotation option = returnType
+    member x.typeParameters: TypeParameterDeclaration option = typeParams
 
 /// If computed is true, the node corresponds to a computed (a[b]) member expression and property is an Expression. 
 /// If computed is false, the node corresponds to a static (a.b) member expression and property is an Identifier.
@@ -501,7 +505,8 @@ type RestElement(argument, ?loc) =
 type ClassMethodKind =
     | ClassConstructor | ClassFunction | ClassGetter | ClassSetter
 
-type ClassMethod(kind, key, args, body, computed, ``static``, ?returnType, ?loc) =
+type ClassMethod(kind, key, args, body, computed, ``static``,
+                 ?returnType, ?typeParams, ?loc) =
     inherit Node("ClassMethod", ?loc = loc)
     member x.kind = match kind with ClassConstructor -> "constructor"
                                   | ClassGetter -> "get"
@@ -513,6 +518,7 @@ type ClassMethod(kind, key, args, body, computed, ``static``, ?returnType, ?loc)
     member x.computed: bool = computed
     member x.``static``: bool = ``static``
     member x.returnType: TypeAnnotation option = returnType
+    member x.typeParameters: TypeParameterDeclaration option = typeParams    
     // member x.decorators: Decorator list = defaultArg decorators []
     // This appears in astexplorer.net but it's not documented
     // member x.expression: bool = false

--- a/src/fable/Fable.Core/AST/AST.Babel.fs
+++ b/src/fable/Fable.Core/AST/AST.Babel.fs
@@ -255,13 +255,14 @@ type ForOfStatement(left, right, body, ?loc) =
     member x.right: Expression = right
 
 /// A function declaration. Note that id cannot be null.
-type FunctionDeclaration(id, arguments, body, ?generator, ?async, ?loc) =
+type FunctionDeclaration(id, arguments, body, ?returnType, ?generator, ?async, ?loc) =
     inherit Declaration("FunctionDeclaration", ?loc = loc)
     member x.id: Identifier = id
     member x.``params``: Pattern list = arguments
     member x.body: BlockStatement = body
     member x.generator = defaultArg generator false
     member x.async = defaultArg async false
+    member x.returnType: TypeAnnotation option = returnType
 
 (** ##Expressions *)
 
@@ -340,13 +341,14 @@ type ObjectProperty(key, value, ?shorthand, ?computed, ?loc) =
 
 type ObjectMethodKind = ObjectGetter | ObjectSetter | ObjectMeth
 
-type ObjectMethod(kind, key, arguments, body, ?computed, ?generator, ?async, ?loc) =
+type ObjectMethod(kind, key, arguments, body, ?returnType, ?computed, ?generator, ?async, ?loc) =
     inherit ObjectMember("ObjectMethod", key, ?computed=computed, ?loc=loc)
     member x.kind = match kind with ObjectGetter -> "get"
                                   | ObjectSetter -> "set"
                                   | ObjectMeth -> "method"
     member x.``params``: Pattern list = arguments
     member x.body: BlockStatement = body
+    member x.returnType: TypeAnnotation option = returnType
     member x.generator: bool = defaultArg generator false
     member x.async: bool = defaultArg async false
 
@@ -499,7 +501,7 @@ type RestElement(argument, ?loc) =
 type ClassMethodKind =
     | ClassConstructor | ClassFunction | ClassGetter | ClassSetter
 
-type ClassMethod(kind, key, args, body, computed, ``static``, ?loc) =
+type ClassMethod(kind, key, args, body, computed, ``static``, ?returnType, ?loc) =
     inherit Node("ClassMethod", ?loc = loc)
     member x.kind = match kind with ClassConstructor -> "constructor"
                                   | ClassGetter -> "get"
@@ -510,6 +512,7 @@ type ClassMethod(kind, key, args, body, computed, ``static``, ?loc) =
     member x.body: BlockStatement = body
     member x.computed: bool = computed
     member x.``static``: bool = ``static``
+    member x.returnType: TypeAnnotation option = returnType
     // member x.decorators: Decorator list = defaultArg decorators []
     // This appears in astexplorer.net but it's not documented
     // member x.expression: bool = false
@@ -639,6 +642,10 @@ type FunctionTypeAnnotation(args, returnType, ?rest) =
     member x.rest: FunctionTypeParam option = rest
     member x.returnType: TypeAnnotationInfo = returnType
 
+type NullableTypeAnnotation(typ) =
+    inherit TypeAnnotationInfo("NullableTypeAnnotation")
+    member x.typeAnnotation: TypeAnnotationInfo = typ
+
 type GenericTypeAnnotation(id, ?typeParams) =
     inherit TypeAnnotationInfo("GenericTypeAnnotation")
     member x.id: Identifier = id
@@ -654,8 +661,8 @@ type ObjectTypeProperty(key, value, ?isStatic, ?isOptional) =
 type ObjectTypeAnnotation(properties) =
     inherit TypeAnnotationInfo("ObjectTypeAnnotation")
     member x.properties: obj list = []
-    // member x.callProperties
-    // member x.indexers
+    member x.callProperties: obj list = []
+    member x.indexers: obj list = []
 
 type InterfaceExtends(id, ?typeParams) =
     member x.``type`` = "InterfaceExtends"

--- a/src/fable/Fable.Core/AST/AST.Fable.Util.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.Util.fs
@@ -14,22 +14,22 @@ type CallKind =
     | GlobalCall of modName: string * meth: string option * isCons: bool * args: Expr list
 
 let makeLoop range loopKind = Loop (loopKind, range)
-let makeIdent name: Ident = {name=name; typ=UnknownType}
+let makeIdent name: Ident = {name=name; typ=Any}
 let makeTypedIdent name typ: Ident = {name=name; typ=typ}
 let makeIdentExpr name = makeIdent name |> IdentValue |> Value
 let makeCoreRef (com: ICompiler) modname prop =
     let import = Value(ImportRef(modname, com.Options.coreLib))
     match prop with
     | None -> import
-    | Some prop -> Apply (import, [Value(StringConst prop)], ApplyGet, UnknownType, None)
+    | Some prop -> Apply (import, [Value(StringConst prop)], ApplyGet, Any, None)
 
 let makeBinOp, makeUnOp, makeLogOp, makeEqOp =
     let makeOp range typ args op =
         Apply (Value op, args, ApplyMeth, typ, range)
     (fun range typ args op -> makeOp range typ args (BinaryOp op)),
     (fun range typ args op -> makeOp range typ args (UnaryOp op)),
-    (fun range args op -> makeOp range (PrimitiveType Boolean) args (LogicalOp op)),
-    (fun range args op -> makeOp range (PrimitiveType Boolean) args (BinaryOp op))
+    (fun range args op -> makeOp range Boolean args (LogicalOp op)),
+    (fun range args op -> makeOp range Boolean args (BinaryOp op))
 
 let rec makeSequential range statements =
     match statements with
@@ -65,18 +65,17 @@ let makeConst (value: obj) =
     | _ -> failwithf "Unexpected literal %O" value
     |> Value
 
-let makeFnType args =
-    PrimitiveType (List.length args |> Function)
+let makeFnType args (body: Expr) =
+    Function(List.map Ident.getType args, body.Type)
+
+let makeUnknownFnType (arity: int) =
+    Function(List.init arity (fun _ -> Any), Any)
 
 let makeGet range typ callee propExpr =
     Apply (callee, [propExpr], ApplyGet, typ, range)
 
 let makeArray elementType arrExprs =
-    let arrayKind =
-        match elementType with
-        | PrimitiveType (Number numberKind) -> TypedArray numberKind
-        | _ -> DynamicArray
-    ArrayConst(ArrayValues arrExprs, arrayKind) |> Value
+    ArrayConst(ArrayValues arrExprs, elementType) |> Value
 
 let tryImported com name (decs: #seq<Decorator>) =
     decs |> Seq.tryPick (fun x ->
@@ -92,24 +91,24 @@ let tryImported com name (decs: #seq<Decorator>) =
 
 let makeTypeRef com (range: SourceLocation option) typ =
     match typ with
-    | PrimitiveType _ ->
-        "Cannot reference a primitive type"
-        |> attachRange range |> failwith
-    | UnknownType ->
-        "Cannot reference unknown type. "
-        + "If this a generic argument, try to make function inline."
-        |> attachRange range |> failwith
-    | DeclaredType ent ->
+    | DeclaredType(ent, _) ->
         match tryImported com ent.Name ent.Decorators with
         | Some expr -> expr
         | None -> Value (TypeRef ent)
+    | Any ->
+        "Cannot reference unknown type. "
+        + "If this a generic argument, try to make function inline."
+        |> attachRange range |> failwith
+    | _ ->
+        sprintf "Cannot reference type %s" typ.FullName
+        |> attachRange range |> failwith
 
 let makeCall com range typ kind =
-    let getCallee meth args owner =
+    let getCallee meth args returnType owner =
         match meth with
         | None -> owner
         | Some meth ->
-            let fnTyp = PrimitiveType (List.length args |> Function)
+            let fnTyp = Function(List.map Expr.getType args, returnType)
             Apply (owner, [makeConst meth], ApplyGet, fnTyp, None)
     let apply kind args callee =
         Apply(callee, args, kind, typ, range)
@@ -117,51 +116,46 @@ let makeCall com range typ kind =
         if isCons then ApplyCons else ApplyMeth
     match kind with
     | InstanceCall (callee, meth, args) ->
-        let fnTyp = PrimitiveType (List.length args |> Function)
+        let fnTyp = Function(List.map Expr.getType args, typ)
         Apply (callee, [makeConst meth], ApplyGet, fnTyp, None)
         |> apply ApplyMeth args
     | ImportCall (importPath, modName, meth, isCons, args) ->
         Value (ImportRef (modName, importPath))
-        |> getCallee meth args
+        |> getCallee meth args typ
         |> apply (getKind isCons) args
     | CoreLibCall (modName, meth, isCons, args) ->
         makeCoreRef com modName None
-        |> getCallee meth args
+        |> getCallee meth args typ
         |> apply (getKind isCons) args
     | GlobalCall (modName, meth, isCons, args) ->
         makeIdentExpr modName
-        |> getCallee meth args
+        |> getCallee meth args typ
         |> apply (getKind isCons) args
 
 let makeTypeTest com range (typ: Type) expr =
-    let stringType, boolType =
-        PrimitiveType String, PrimitiveType Boolean
     let checkType (primitiveType: string) expr =
-        let typof = makeUnOp None stringType [expr] UnaryTypeof
-        makeBinOp range boolType [typof; makeConst primitiveType] BinaryEqualStrict
+        let typof = makeUnOp None String [expr] UnaryTypeof
+        makeBinOp range Boolean [typof; makeConst primitiveType] BinaryEqualStrict
     match typ with
-    | PrimitiveType kind ->
-        match kind with
-        | String _ -> checkType "string" expr
-        | Number _ -> checkType "number" expr
-        | Boolean -> checkType "boolean" expr
-        | Unit -> makeBinOp range boolType [expr; Value Null] BinaryEqual
-        | Function _ -> checkType "function" expr
-        // TODO: Regex and Array?
-        | _ -> failwithf "Unsupported type test: %A" typ
-    | DeclaredType typEnt ->
+    | String _ -> checkType "string" expr
+    | Number _ -> checkType "number" expr
+    | Boolean -> checkType "boolean" expr
+    | Unit -> makeBinOp range Boolean [expr; Value Null] BinaryEqual
+    | Function _ -> checkType "function" expr
+    // TODO: Regex and Array?
+    | DeclaredType(typEnt, _) ->
         match typEnt.Kind with
         | Interface ->
             CoreLibCall ("Util", Some "hasInterface", false, [expr; makeConst typEnt.FullName])
-            |> makeCall com range boolType
+            |> makeCall com range Boolean
         | _ ->
-            makeBinOp range boolType [expr; makeTypeRef com range typ] BinaryInstanceOf
+            makeBinOp range Boolean [expr; makeTypeRef com range typ] BinaryInstanceOf
     | _ -> "Unsupported type test: " + typ.FullName
             |> attachRange range |> failwith
 
 let makeUnionCons () =
     let emit = Emit "this.Case=caseName; this.Fields = fields;" |> Value
-    let body = Apply (emit, [], ApplyMeth, PrimitiveType Unit, None)
+    let body = Apply (emit, [], ApplyMeth, Unit, None)
     Member(".ctor", Constructor, SourceLocation.Empty, [makeIdent "caseName"; makeIdent "fields"], body, [], true)
     |> MemberDeclaration
 
@@ -174,20 +168,19 @@ let makeRecordCons props =
         props |> List.mapi (fun i _ -> sprintf "$arg%i" i |> makeIdent),
         props |> Seq.mapi (fun i x ->
             sprintf "this%s=$arg%i" (sanitizeField x) i) |> String.concat ";"
-    let body = Apply (Value (Emit body), [], ApplyMeth, PrimitiveType Unit, None)
+    let body = Apply (Value (Emit body), [], ApplyMeth, Unit, None)
     Member(".ctor", Constructor, SourceLocation.Empty, args, body, [], true, false, false)
     |> MemberDeclaration
 
 let makeUnionCompareMethods, makeRecordCompareMethods =
-    let boolType, intType = PrimitiveType Boolean, PrimitiveType(Number Int32)
     let meth com typ name coreMeth =
         let arg = makeIdent "x"
         let body =
             CoreLibCall("Util", Some coreMeth, false, [Value This; Value(IdentValue arg)])
             |> makeCall com None typ
         Member(name, Method, SourceLocation.Empty, [arg], body) |> MemberDeclaration
-    (fun (com: ICompiler) -> [meth com boolType "Equals" "equalsUnions"; meth com intType "CompareTo" "compareUnions"]),
-    (fun (com: ICompiler) -> [meth com boolType "Equals" "equalsRecords"; meth com intType "CompareTo" "compareRecords"])
+    (fun (com: ICompiler) -> [meth com Boolean "Equals" "equalsUnions"; meth com (Number Int32) "CompareTo" "compareUnions"]),
+    (fun (com: ICompiler) -> [meth com Boolean "Equals" "equalsRecords"; meth com (Number Int32) "CompareTo" "compareRecords"])
 
 let makeDelegate arity (expr: Expr) =
     let rec flattenLambda (arity: int option) accArgs = function
@@ -202,12 +195,12 @@ let makeDelegate arity (expr: Expr) =
         | Some arity when arity > 1 ->
             let lambdaArgs =
                 [for i=1 to arity do
-                    yield {name=Naming.getUniqueVar(); typ=UnknownType}]
+                    yield {name=Naming.getUniqueVar(); typ=Any}]
             let lambdaBody =
                 (expr, lambdaArgs)
                 ||> List.fold (fun callee arg ->
                     Apply (callee, [Value (IdentValue arg)],
-                        ApplyMeth, UnknownType, expr.Range))
+                        ApplyMeth, Any, expr.Range))
             Lambda (lambdaArgs, lambdaBody) |> Value
         | _ -> expr // Do nothing
     match expr, expr.Type with
@@ -215,8 +208,8 @@ let makeDelegate arity (expr: Expr) =
         match flattenLambda arity args body with
         | Some expr -> expr
         | None -> wrap arity expr
-    | _, PrimitiveType (Function a) ->
-        let arity = defaultArg arity a 
+    | _, Function(args,_) ->
+        let arity = defaultArg arity (List.length args)
         wrap (Some arity) expr
     | _ -> expr
 
@@ -225,7 +218,7 @@ let makeApply range typ callee exprs =
     let lasti = (List.length exprs) - 1
     ((0, callee), exprs)
     ||> List.fold (fun (i, callee) expr ->
-        let typ = if i = lasti then typ else PrimitiveType (Function <|i+1)
+        let typ = if i = lasti then typ else makeUnknownFnType (i+1)
         let callee =
             match callee with
             | Sequential _ ->
@@ -242,7 +235,7 @@ let makeJsObject range (props: (string * Expr) list) =
 
 let makeEmit args macro =
     let emit = Fable.Emit macro |> Fable.Value
-    Fable.Apply(emit, args, Fable.ApplyMeth, Fable.UnknownType, None)    
+    Fable.Apply(emit, args, Fable.ApplyMeth, Fable.Any, None)    
     
 let getTypedArrayName (com: ICompiler) numberKind =
     match numberKind with

--- a/src/fable/Fable.Core/AST/AST.Fable.Util.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.Util.fs
@@ -95,11 +95,12 @@ let makeTypeRef com (range: SourceLocation option) typ =
         match tryImported com ent.Name ent.Decorators with
         | Some expr -> expr
         | None -> Value (TypeRef ent)
-    | Any ->
-        "Cannot reference unknown type. "
-        + "If this a generic argument, try to make function inline."
+    | GenericParam name ->
+        "Cannot reference generic parameter " + name
+        + ". Try to make function inline."
         |> attachRange range |> failwith
     | _ ->
+        // TODO: Reference JS objects? Object, String, Number...
         sprintf "Cannot reference type %s" typ.FullName
         |> attachRange range |> failwith
 

--- a/src/fable/Fable.Core/AST/AST.Fable.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.fs
@@ -90,11 +90,13 @@ and MemberKind =
     | Setter
     | Field
 
-and Member(name, kind, range, args, body, ?decorators, ?isPublic, ?isMutable, ?isStatic, ?hasRestParams, ?privateName) =
+and Member(name, kind, range, args, body, ?genParams, ?decorators,
+           ?isPublic, ?isMutable, ?isStatic, ?hasRestParams, ?privateName) =
     member x.Name: string = name
     member x.Kind: MemberKind = kind
     member x.Range: SourceLocation = range
     member x.Arguments: Ident list = args
+    member x.GenericParameters: string list = defaultArg genParams []
     member x.Body: Expr = body
     member x.Decorators: Decorator list = defaultArg decorators []
     member x.IsPublic: bool = defaultArg isPublic true

--- a/src/fable/Fable.Core/AST/AST.Fable.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.fs
@@ -43,10 +43,10 @@ type Type =
 (** ##Entities *)
 and EntityKind =
     | Module
-    | Class of baseClass: (string*Expr) option
     | Union
-    | Record
-    | Exception
+    | Record of fields: (string*Type) list
+    | Exception of fields: (string*Type) list
+    | Class of baseClass: (string*Expr) option
     | Interface
 
 and Entity(kind, file, fullName, genParams, interfaces, decorators, isPublic) =

--- a/src/fable/Fable.Core/Compiler.fs
+++ b/src/fable/Fable.Core/Compiler.fs
@@ -10,6 +10,7 @@ type CompilerOptions = {
         watch: bool
         clamp: bool
         copyExt: bool
+        declaration: bool
         extra: Map<string, string>
     }
 

--- a/src/plugins/bitwise-wrap/Fable.Plugins.BitwiseWrap.fsx
+++ b/src/plugins/bitwise-wrap/Fable.Plugins.BitwiseWrap.fsx
@@ -16,7 +16,7 @@ type BitwiseWrapPlugin() =
             | "Microsoft.FSharp.Core.Operators" ->
                 let patternFor t = 
                     match t with
-                    | PrimitiveType (Number kind) -> 
+                    | Number kind -> 
                         match kind with
                         | Int8 -> Some "($0 + 0x80 & 0xFF) - 0x80"
                         | UInt8 -> Some "$0 & 0xFF"

--- a/src/plugins/nunit/Fable.Plugins.NUnit.fsx
+++ b/src/plugins/nunit/Fable.Plugins.NUnit.fsx
@@ -41,7 +41,7 @@ module Util =
                 let doneFn = doneFn |> Fable.IdentValue |> Fable.Value
                 let args = [asyncBuilder; doneFn; doneFn; doneFn]
                 AST.Fable.Util.CoreLibCall("Async", Some "startWithContinuations", false, args)
-                |> AST.Fable.Util.makeCall com range (Fable.PrimitiveType Fable.Unit)
+                |> AST.Fable.Util.makeCall com range Fable.Unit
             [doneFn], testBody
         if test.Arguments.Length > 0 then
             failwithf "Test parameters are not supported (testName = '%s')." name
@@ -129,8 +129,8 @@ type NUnitPlugin() =
             | "NUnit.Framework.Assert", _ -> asserts com info
             | "Microsoft.FSharp.Control.FSharpAsync", "RunSynchronously" ->
                 match info.returnType with
-                | Fable.PrimitiveType Fable.Unit ->
-                    let warning = Fable.Throw(Fable.Value(Fable.StringConst Util.runSyncWarning), Fable.PrimitiveType Fable.Unit, None)
+                | Fable.Unit ->
+                    let warning = Fable.Throw(Fable.Value(Fable.StringConst Util.runSyncWarning), Fable.Unit, None)
                     AST.Fable.Util.makeSequential info.range [warning; info.args.Head] |> Some 
                 | _ -> failwithf "Async.RunSynchronously in tests is only allowed with Async<unit> %O" info.range
             | _ -> None

--- a/src/plugins/vs-unit-tests/Fable.Plugins.VisualStudio.UnitTests.fsx
+++ b/src/plugins/vs-unit-tests/Fable.Plugins.VisualStudio.UnitTests.fsx
@@ -58,7 +58,7 @@ module Util =
                 let doneFn = doneFn |> Fable.IdentValue |> Fable.Value
                 let args = [asyncBuilder; doneFn; doneFn; doneFn]
                 AST.Fable.Util.CoreLibCall("Async", Some "startWithContinuations", false, args)
-                |> AST.Fable.Util.makeCall com range (Fable.PrimitiveType Fable.Unit)
+                |> AST.Fable.Util.makeCall com range Fable.Unit
             [doneFn], testBody
         if testMethod.Arguments.Length > 0 then
             failwithf "Test parameters are not supported (testName = '%s')." name
@@ -146,8 +146,8 @@ type VisualStudioUnitTestsPlugin() =
             | "Microsoft.VisualStudio.TestTools.UnitTesting.Assert", _ -> asserts com info
             | "Microsoft.FSharp.Control.FSharpAsync", "RunSynchronously" ->
                 match info.returnType with
-                | Fable.PrimitiveType Fable.Unit ->
-                    let warning = Fable.Throw(Fable.Value(Fable.StringConst Util.runSyncWarning), Fable.PrimitiveType Fable.Unit, None)
+                | Fable.Unit ->
+                    let warning = Fable.Throw(Fable.Value(Fable.StringConst Util.runSyncWarning), Fable.Unit, None)
                     AST.Fable.Util.makeSequential info.range [warning; info.args.Head] |> Some 
                 | _ -> failwithf "Async.RunSynchronously in tests is only allowed with Async<unit> %O" info.range
             | _ -> None


### PR DESCRIPTION
This PR extends Fable AST to make it easier to add [Flow](https://flowtype.org) type annotations when transforming it into Babel AST. These annotations can then be used by the [babel-dts-generator](https://github.com/YoloDev/babel-dts-generator) plugin to generate `d.ts` declarations.

The declarations are far from perfect. These are some of the things missing:

- [x] Generic arguments: everything is already laid down to add them, we only need to fill in the gaps.
- [x] Class properties: a bit more of work, as class properties have to be added explicitly at least for unions and records.
- [ ] Interfaces: it also requires some work as Fable is ignoring abstract methods at the moment.
- [ ] Nested modules: I can foresee some pain here.

I'll try to implement at least the first two points before merging, but probably the other two will be postponed to another release.