### PR TITLE
Do not delete obj dirs in node_modules

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -144,8 +144,9 @@ module Fake =
 // Targets
 Target "Clean" (fun _ ->
     // Don't delete node_modules for faster builds
-    !! "build/fable/bin" ++ "src/fable/**/obj/"
+    !! "build/fable/bin" ++ "src/fable/*/obj/"
     |> CleanDirs
+
     !! "build/fable/**/*.*" -- "build/fable/node_modules/**/*.*"
     |> Seq.iter FileUtils.rm
     !! "build/tests/**/*.*" -- "build/tests/node_modules/**/*.*"


### PR DESCRIPTION
On Windows, deleting `src/fable/**/obj` causes error because "path too long". I suspect this is because FAKE tries looking into `src/fable/Fable.Core/npm/node_modules` to see if there are any `obj` folders there.

AFAIK, this change means that only `obj` folders immediately under `fable`, e.g. `fable/Fable.Core/obj`, but not in more deeply nested folders - which seems to fix the issue for me!