### PR TITLE
Specify whether path is directory explicitly (fix #318)

### DIFF
--- a/src/fable/Fable.Compiler/Fable2Babel.fs
+++ b/src/fable/Fable.Compiler/Fable2Babel.fs
@@ -145,7 +145,7 @@ module Util =
                 match proj.ImportPath with
                 | Some importPath ->
                     let ext = Path.getExternalImportPath com ctx.fixedFileName importPath
-                    let rel = Path.getRelativePath proj.BaseDir file
+                    let rel = Path.getRelativeFileOrDirPath true proj.BaseDir false file
                     System.IO.Path.Combine(ext, rel)
                     |> Path.normalizePath
                     |> fun x -> System.IO.Path.ChangeExtension(x, null)

--- a/src/fable/Fable.Core/Util.fs
+++ b/src/fable/Fable.Core/Util.fs
@@ -149,14 +149,14 @@ module Path =
 
     /// Creates a relative path from one file or folder to another.
     /// from http://stackoverflow.com/a/340454/3922220
-    let getRelativePath fromPath toPath =
+    let getRelativeFileOrDirPath fromIsDir fromPath toIsDir toPath =
         // Add a dummy file to make it work correctly with dirs
-        let addDummyFile path =
-            if IO.Directory.Exists(path)
+        let addDummyFile isDir path =
+            if isDir
             then IO.Path.Combine(path, "dummy.txt")
             else path
-        let fromPath = addDummyFile fromPath
-        let toPath = addDummyFile toPath
+        let fromPath = addDummyFile fromIsDir fromPath
+        let toPath = addDummyFile toIsDir toPath
         let fromUri = Uri(fromPath)
         let toUri = Uri(toPath)
         if fromUri.Scheme <> toUri.Scheme then
@@ -169,6 +169,11 @@ module Path =
                             IO.Path.AltDirectorySeparatorChar,
                             IO.Path.DirectorySeparatorChar)  |> normalizePath
             | _ -> relativePath |> normalizePath
+
+    let getRelativePath fromPath toPath =
+        getRelativeFileOrDirPath 
+          (IO.Directory.Exists fromPath) fromPath 
+          (IO.Directory.Exists toPath) toPath
 
     let getExternalImportPath (com: ICompiler) (filePath: string) (importPath: string) =
         if not(importPath.StartsWith ".")


### PR DESCRIPTION
The issue was that `getRelativePath "C:/foo" "C:/foo/file.txt"` returns `foo/file.txt` when the path `C:/foo` does not exist. For some reason, when I rename folders, the path `proj.BaseDir` sometimes ends up being the old path (I guess it's Windows 8.1 thing :bomb:).

The fix is quite simple though - we know that `proj.BaseDir` is a directory and `file` is a file, so we can just specify this explicitly, rather than detecting whether path is a directory by calling `Directory.Exists`.

:white_check_mark: 806 passing now!