### PR TITLE
New post API for Fetch

### DIFF
--- a/import/fetch/Fable.Helpers.Fetch.fs
+++ b/import/fetch/Fable.Helpers.Fetch.fs
@@ -51,3 +51,10 @@ let inline fetchAs<'T> (req: RequestInfo) : Async<'T> = async {
     let! json = fetched.text() |> Async.AwaitPromise
     return ofJson<'T> json    
 }
+
+/// Sends a HTTP post with the record serialized as JSON  
+let inline postRecord<'T> (req: RequestInfo,record:'T) : Async<Response> =
+    fetchAsyncWithInit(
+      req, 
+      [ RequestProperties.Method HttpMethod.POST
+        RequestProperties.Body (unbox (toJson record))])

--- a/import/fetch/Fable.Helpers.Fetch.fs
+++ b/import/fetch/Fable.Helpers.Fetch.fs
@@ -7,17 +7,40 @@ open Fable.Core
 open Fable.Import
 open Fable.Core.JsInterop
 
+type [<StringEnum; RequireQualifiedAccess>] HttpMethod =
+| [<CompiledName("GET")>] GET 
+| [<CompiledName("HEAD")>] HEAD 
+| [<CompiledName("POST")>] POST 
+| [<CompiledName("PUT")>] PUT 
+| [<CompiledName("DELETE")>] DELETE 
+| [<CompiledName("TRACE")>] TRACE
+| [<CompiledName("CONNECT")>] CONNECT
+
+[<KeyValueList>]
+type IRequestProperties =
+    interface end
+
+[<KeyValueList>]
+type RequestProperties =
+    | Method of HttpMethod
+    | Headers of U2<HeaderInit, obj>
+    | Body of BodyInit
+    | Mode of RequestMode
+    | Credentials of RequestCredentials
+    | Cache of RequestCache
+    interface IRequestProperties
+
 /// Retrieves data from the specified resource.
-let inline fetchAsyncWithInit (req: RequestInfo, init: RequestInit) : Async<Response> = 
-    GlobalFetch.fetch(req, init) |> Async.AwaitPromise
+let inline fetchAsyncWithInit (req: RequestInfo, init: RequestProperties list) : Async<Response> = 
+    GlobalFetch.fetch(req, unbox init) |> Async.AwaitPromise
 
 /// Retrieves data from the specified resource.
 let inline fetchAsync (req: RequestInfo) : Async<Response> = 
     GlobalFetch.fetch(req) |> Async.AwaitPromise
 
 /// Retrieves data from the specified resource, parses the json and returns the data as an object of type 'T.
-let inline fetchAsWithInit<'T> (req: RequestInfo, init: RequestInit) : Async<'T> = async {
-    let! fetched = GlobalFetch.fetch(req, init) |> Async.AwaitPromise
+let inline fetchAsWithInit<'T> (req: RequestInfo, init: RequestProperties list) : Async<'T> = async {
+    let! fetched = GlobalFetch.fetch(req, unbox init) |> Async.AwaitPromise
     let! json = fetched.text() |> Async.AwaitPromise
     return ofJson<'T> json
 }

--- a/import/fetch/Fable.Helpers.Fetch.fs
+++ b/import/fetch/Fable.Helpers.Fetch.fs
@@ -19,13 +19,66 @@ type [<StringEnum; RequireQualifiedAccess>] HttpMethod =
 | [<CompiledName("CONNECT")>] CONNECT
 
 [<KeyValueList>]
+type IHttpRequestHeaders =
+    interface end
+
+[<KeyValueList>]
+type HttpRequestHeaders =
+    | Accept of string
+    | [<CompiledName("Accept-Charset")>] AcceptCharset of string
+    | [<CompiledName("Accept-Encoding")>] AcceptEncoding of string
+    | [<CompiledName("Accept-Language")>] AcceptLanguage of string
+    | [<CompiledName("Accept-Datetime")>] AcceptDatetime of string
+    | Authorization of string
+    | [<CompiledName("Cache-Control")>] CacheControl of string
+    | Connection of string
+    | Cookie of string
+    | [<CompiledName("Content-Length")>] ContentLength of string
+    | [<CompiledName("Content-MD5")>] ContentMD5 of string
+    | [<CompiledName("ContentType")>] ContentType of string
+    | Date of string
+    | Expect of string
+    | Forwarded of string
+    | From of string
+    | Host of string
+    | [<CompiledName("If-Match")>] IfMatch of string
+    | [<CompiledName("If-Modified-Since")>] IfModifiedSince of string
+    | [<CompiledName("If-None-Match")>] IfNoneMatch of string
+    | [<CompiledName("If-Range")>] IfRange of string
+    | [<CompiledName("If-Unmodified-Since")>] IfUnmodifiedSince of string
+    | [<CompiledName("Max-Forwards")>] MaxForwards of int
+    | Origin of string
+    | Pragma of string
+    | [<CompiledName("Proxy-Authorization")>] ProxyAuthorization of string
+    | Range of string
+    | Referer of string
+    | [<CompiledName("TE")>] TE of string
+    | [<CompiledName("User-Agent")>] UserAgent of string
+    | Upgrade of string
+    | Via of string
+    | Warning of string
+    | [<CompiledName("X-Requested-With")>] XRequestedWith of string
+    | [<CompiledName("DNT")>] DNT of string
+    | [<CompiledName("X-Forwarded-For")>] XForwardedFor of string
+    | [<CompiledName("X-Forwarded-Host")>] XForwardedHost of string
+    | [<CompiledName("X-Forwarded-Proto")>] XForwardedProto of string
+    | [<CompiledName("Front-End-Https")>] FrontEndHttps of string
+    | [<CompiledName("X-Http-Method-Override")>] XHttpMethodOverride of string
+    | [<CompiledName("X-ATT-DeviceId")>] XATTDeviceId of string
+    | [<CompiledName("X-Wap-Profile")>] XWapProfile of string
+    | [<CompiledName("Proxy-Connection")>] ProxyConnection of string
+    | [<CompiledName("X-UIDH")>] XUIDH of string
+    | [<CompiledName("X-Csrf-Token")>] XCsrfToken of string
+    interface IHttpRequestHeaders
+
+[<KeyValueList>]
 type IRequestProperties =
     interface end
 
 [<KeyValueList>]
 type RequestProperties =
     | Method of HttpMethod
-    | Headers of U2<HeaderInit, obj>
+    | Headers of HttpRequestHeaders list
     | Body of BodyInit
     | Mode of RequestMode
     | Credentials of RequestCredentials

--- a/import/fetch/Fable.Helpers.Fetch.fs
+++ b/import/fetch/Fable.Helpers.Fetch.fs
@@ -43,9 +43,14 @@ let inline fetchAs<'T> (url:string, init: RequestProperties list) : Async<'T> = 
     return ofJson<'T> json    
 }
 
+[<Emit("Object.assign({}, $0, $1)")>]
+let inline private ( ++ ) (a:'a list) (b:'a list) : 'a list = failwith "JS Only"
+
 /// Sends a HTTP post with the record serialized as JSON  
-let inline postRecord<'T> (url,record:'T) : Async<Response> =
-    fetchAsync(
-        url, 
+let inline postRecord<'T> (url,record:'T, properties: RequestProperties list) : Async<Response> =
+    let props = 
         [ RequestProperties.Method HttpMethod.POST
-          RequestProperties.Body (unbox (toJson record))])
+          RequestProperties.Body (unbox (toJson record))]
+          ++ properties 
+
+    fetchAsync(url,props)

--- a/import/fetch/Fable.Helpers.Fetch.fs
+++ b/import/fetch/Fable.Helpers.Fetch.fs
@@ -46,7 +46,8 @@ let inline fetchAs<'T> (url:string, init: RequestProperties list) : Async<'T> = 
 [<Emit("Object.assign({}, $0, $1)")>]
 let inline private ( ++ ) (a:'a list) (b:'a list) : 'a list = failwith "JS Only"
 
-/// Sends a HTTP post with the record serialized as JSON  
+/// Sends a HTTP post with the record serialized as JSON.
+/// This function already sets the HTTP Method to POST sets the json into the body.
 let inline postRecord<'T> (url,record:'T, properties: RequestProperties list) : Async<Response> =
     let props = 
         [ RequestProperties.Method HttpMethod.POST

--- a/import/fetch/Fable.Helpers.Fetch.fs
+++ b/import/fetch/Fable.Helpers.Fetch.fs
@@ -1,4 +1,6 @@
 [<Fable.Core.Erase>]
+/// The Fetch API provides a JavaScript interface for accessing and manipulating parts of the HTTP pipeline, such as requests and responses. 
+/// It also provides a global fetch() method that provides an easy, logical way to fetch resources asynchronously across the network.
 module internal Fable.Helpers.Fetch
 
 open System

--- a/import/fetch/Fable.Helpers.Fetch.fs
+++ b/import/fetch/Fable.Helpers.Fetch.fs
@@ -31,30 +31,19 @@ type RequestProperties =
     interface IRequestProperties
 
 /// Retrieves data from the specified resource.
-let inline fetchAsyncWithInit (req: RequestInfo, init: RequestProperties list) : Async<Response> = 
-    GlobalFetch.fetch(req, unbox init) |> Async.AwaitPromise
-
-/// Retrieves data from the specified resource.
-let inline fetchAsync (req: RequestInfo) : Async<Response> = 
-    GlobalFetch.fetch(req) |> Async.AwaitPromise
-
-/// Retrieves data from the specified resource, parses the json and returns the data as an object of type 'T.
-let inline fetchAsWithInit<'T> (req: RequestInfo, init: RequestProperties list) : Async<'T> = async {
-    let! fetched = GlobalFetch.fetch(req, unbox init) |> Async.AwaitPromise
-    let! json = fetched.text() |> Async.AwaitPromise
-    return ofJson<'T> json
-}
+let inline fetchAsync (url:string, init: RequestProperties list) : Async<Response> = 
+    GlobalFetch.fetch(url, unbox init) |> Async.AwaitPromise
 
 /// Retrieves data from the specified resource, parses the json and returns the data as an object of type 'T. 
-let inline fetchAs<'T> (req: RequestInfo) : Async<'T> = async {
-    let! fetched = GlobalFetch.fetch(req) |> Async.AwaitPromise
+let inline fetchAs<'T> (url:string, init: RequestProperties list) : Async<'T> = async {
+    let! fetched = GlobalFetch.fetch(url, unbox init) |> Async.AwaitPromise
     let! json = fetched.text() |> Async.AwaitPromise
     return ofJson<'T> json    
 }
 
 /// Sends a HTTP post with the record serialized as JSON  
-let inline postRecord<'T> (req: RequestInfo,record:'T) : Async<Response> =
-    fetchAsyncWithInit(
-      req, 
-      [ RequestProperties.Method HttpMethod.POST
-        RequestProperties.Body (unbox (toJson record))])
+let inline postRecord<'T> (url,record:'T) : Async<Response> =
+    fetchAsync(
+        url, 
+        [ RequestProperties.Method HttpMethod.POST
+          RequestProperties.Body (unbox (toJson record))])

--- a/import/fetch/Fable.Import.Fetch.fs
+++ b/import/fetch/Fable.Import.Fetch.fs
@@ -88,3 +88,7 @@ module Fetch =
         
     type GlobalFetch =
         [<Global>]static member fetch (req: RequestInfo, ?init: RequestInit) = failwith "JS only" :Promise<Response>
+
+        [<Global>]static member fetch (url:string, ?init: RequestInit) = failwith "JS only" :Promise<Response>
+
+        [<Global>]static member fetch (url:Request, ?init: RequestInit) = failwith "JS only" :Promise<Response>

--- a/import/fetch/Fable.Import.Fetch.fs
+++ b/import/fetch/Fable.Import.Fetch.fs
@@ -87,4 +87,4 @@ module Fetch =
         | Req of Request
         
     type GlobalFetch =
-        [<Global>]static member fetch (req: RequestInfo, ?init: RequestInit) =  failwith "JS only" :Promise<Response>
+        [<Global>]static member fetch (req: RequestInfo, ?init: RequestInit) = failwith "JS only" :Promise<Response>

--- a/import/fetch/Fable.Import.Fetch.fs
+++ b/import/fetch/Fable.Import.Fetch.fs
@@ -18,8 +18,7 @@ module Fetch =
         inherit Body()
         abstract ``method`` : string with get
         abstract url: string with get
-        abstract headers: Headers with get
-        //Deprecated: abstract context: U2<string,RequestContext> 
+        abstract headers: Headers with get 
         abstract referrer: string with get
         abstract mode: U2<string,RequestMode> with get
         abstract credentials: U2<string,RequestCredentials> with get
@@ -64,6 +63,9 @@ module Fetch =
 
     and [<AbstractClass; Import("*","Response")>] Response(?body: BodyInit, ?init: ResponseInit) =
         inherit Body()
+
+        /// Verifies that the fetch was successful
+        abstract ok: bool
 
     and [<StringEnum; RequireQualifiedAccess>] ResponseType =
         | Basic | Cors | Default | Error | Opaque

--- a/import/fetch/Fable.Import.Fetch.fs
+++ b/import/fetch/Fable.Import.Fetch.fs
@@ -87,7 +87,10 @@ module Fetch =
         | Url of string
         /// Uses a Request object as request info
         | Req of Request
-        
+    
+    
+    /// The Fetch API provides a JavaScript interface for accessing and manipulating parts of the HTTP pipeline, such as requests and responses. 
+    /// It also provides a global fetch() method that provides an easy, logical way to fetch resources asynchronously across the network.
     type GlobalFetch =
         [<Global>]static member fetch (req: RequestInfo, ?init: RequestInit) = failwith "JS only" :Promise<Response>
 

--- a/import/fetch/README.md
+++ b/import/fetch/README.md
@@ -54,7 +54,10 @@ async {
 
 // posting data to a server
 async { 
-    let! response = postRecord("http://www.server.com/data.json", myRecord)
+    let! response = postRecord("http://www.server.com/data.json", myRecord,
+                      [ RequestProperties.Headers [ 
+                          HttpRequestHeaders.Accept "application/xml" ]
+                      ])
     // ...              
 }
 

--- a/import/fetch/README.md
+++ b/import/fetch/README.md
@@ -48,4 +48,15 @@ async {
     | error -> ...
 } 
 
+// posting data to a server
+async { 
+    let! response =
+        fetchAsyncWithInit(
+            RequestInfo.Url "http://www.server.com/data.json" , 
+            [ RequestProperties.Method HttpMethod.POST
+              RequestProperties.Body (unbox "hello world3!!")])
+
+        // ...              
+}
+
 ```

--- a/import/fetch/README.md
+++ b/import/fetch/README.md
@@ -1,6 +1,11 @@
 # fable-import-fetch
 
 Fable bindings for Fetch API
+
+
+The Fetch API provides a JavaScript interface for accessing and manipulating parts of the HTTP pipeline, such as requests and responses. 
+It also provides a global fetch() method that provides an easy, logical way to fetch resources asynchronously across the network.
+
 See: https://developer.mozilla.org/en/docs/Web/API/Fetch_API
 
 ## Installation
@@ -41,8 +46,7 @@ open Fable.Helpers.Fetch
 // getting data and parsing from JSON
 async { 
     try 
-        let! records =
-            fetchAs<MyRecord[]>(RequestInfo.Url "http://www.server.com/data.json" 
+        let! records = fetchAs<MyRecord[]>("http://www.server.com/data.json" , [])
         // ...
     with
     | error -> ...
@@ -50,13 +54,8 @@ async {
 
 // posting data to a server
 async { 
-    let! response =
-        fetchAsyncWithInit(
-            RequestInfo.Url "http://www.server.com/data.json" , 
-            [ RequestProperties.Method HttpMethod.POST
-              RequestProperties.Body (unbox "hello world3!!")])
-
-        // ...              
+    let! response = postRecord("http://www.server.com/data.json", myRecord)
+    // ...              
 }
 
 ```

--- a/import/fetch/package.json
+++ b/import/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-import-fetch",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Fable bindings for Fetch",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will make it easier to post data 

    async { 
        let! response =
            fetchAsyncWithInit(
                RequestInfo.Url "http://www.server.com/data.json" , 
                [ RequestProperties.Method HttpMethod.POST
                  RequestProperties.Body (unbox "hello world3!!")])
    
            // ...              
    }

Open questions:

* how to make body nicer?
* why is the first parameter of fetch a 

    type RequestInfo =
        | Url of string
        | Req of Request

it looks to me that Request can't be changed!?

/cc @7sharp9 

I also would like to see the inverse of

    let inline fetchAs<'T> (req: RequestInfo) : Async<'T> = async {
        let! fetched = GlobalFetch.fetch(req) |> Async.AwaitPromise
        let! json = fetched.text() |> Async.AwaitPromise
        return ofJson<'T> json    
    }

how would that look like?
Currently I have:

    /// Sends a HTTP post with the record serialized as JSON  
    let inline postRecord<'T> (req: RequestInfo,record:'T) : Async<Response> =
        fetchAsyncWithInit(
          req, 
          [ RequestProperties.Method HttpMethod.POST
            RequestProperties.Body (unbox (toJson record))])